### PR TITLE
[fix] find_package order of PCL and catkin

### DIFF
--- a/mins/CMakeLists.txt
+++ b/mins/CMakeLists.txt
@@ -12,6 +12,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Suppress unnecessary warnings: https://github.com/PointCloudLibrary/pcl/issues/3680
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
 
+# Enable compile optimizations
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
+
+# Enable debug flags (use if you want to debug in gdb)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
+
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
 find_package(Eigen3 REQUIRED QUIET)
@@ -20,21 +26,17 @@ if (NOT OpenCV_FOUND)
     find_package(OpenCV 3 REQUIRED QUIET)
 endif ()
 find_package(Boost REQUIRED QUIET COMPONENTS system filesystem thread date_time program_options chrono)
-find_package(PCL REQUIRED QUIET)
 find_package(libpointmatcher REQUIRED QUIET)
 find_package(libnabo REQUIRED QUIET)
 
-message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | LIBPOINTMATCHER: " ${libpointmatcher_VERSION})
-message(STATUS "Eigen3: " ${Eigen3_VERSION} " | PCL: " ${PCL_VERSION} "   | LIBNABO: " ${libnabo_VERSION})
-
-# Enable compile optimizations
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
-
-# Enable debug flags (use if you want to debug in gdb)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
-
 # Find ROS build system
 find_package(catkin REQUIRED COMPONENTS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs image_geometry visualization_msgs image_transport cv_bridge ov_core pcl_ros)
+
+# Find PCL after find catkin
+find_package(PCL REQUIRED QUIET)
+
+message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION} " | LIBPOINTMATCHER: " ${libpointmatcher_VERSION})
+message(STATUS "Eigen3: " ${Eigen3_VERSION} " | PCL: " ${PCL_VERSION} "   | LIBNABO: " ${libnabo_VERSION})
 
 add_definitions(-DROS_AVAILABLE=1)
 


### PR DESCRIPTION
This issue is mentioned in https://github.com/ros-perception/perception_pcl/issues/351, find pcl first will cause catkin didn't set correct CMAKE_PREFIX_PATH, leading to an error.