### PR TITLE
Fix ros2 colcon build paths and add ros2 build CI

### DIFF
--- a/.github/workflows/build_ros2.yml
+++ b/.github/workflows/build_ros2.yml
@@ -1,0 +1,17 @@
+name: ROS 2 Workflow
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_humble:
+    name: "ROS2 Ubuntu 22.04"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Docker image (Humble 22.04)
+        run: docker build . --file Dockerfile_humble_22_04 --tag mins:humble

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,6 @@
 # MINS
 [![ROS 1 Workflow](https://github.com/rpng/MINS/actions/workflows/build_ros1.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1.yml)
+[![ROS 2 Workflow](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml)
 
 An efficient, robust, and tightly-coupled **Multisensor-aided Inertial Navigation System (MINS)** which is capable of 
 flexibly fusing all five sensing modalities (**IMU**, **wheel** **encoders**, **camera**, **GNSS**, and **LiDAR**) in a filtering 

--- a/build_ros2.sh
+++ b/build_ros2.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
+set -e
+
+# MINS repo root (dir holding this script) and the colcon workspace root above src/.
+MINS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${MINS_DIR}/../.."
 
 source /opt/ros/humble/setup.bash
-colcon build --paths thirdparty/*
+colcon build --paths "${MINS_DIR}"/thirdparty/*
 source install/setup.bash
-colcon build --paths thirdparty/open_vins/*
+colcon build --paths "${MINS_DIR}"/thirdparty/open_vins/*
 source install/setup.bash
-colcon build --paths mins mins_data
+colcon build --paths "${MINS_DIR}"/mins "${MINS_DIR}"/mins_data
 source install/setup.bash
-colcon build --paths mins_eval
+colcon build --paths "${MINS_DIR}"/mins_eval

--- a/mins_eval/cmake/ROS2.cmake
+++ b/mins_eval/cmake/ROS2.cmake
@@ -10,6 +10,11 @@ find_package(std_msgs REQUIRED)
 
 find_package(ov_core REQUIRED)   # Might not be available as a ROS 2 package
 find_package(ov_eval REQUIRED)   # Might not be available as a ROS 2 package
+# mins (below) exports libpointmatcher/libnabo, so they must be in scope here
+# to resolve the imported pointmatcher target. ROS1 mins_eval does not link
+# mins and so does not need these (see CMakeLists.txt).
+find_package(libpointmatcher REQUIRED)
+find_package(libnabo REQUIRED)
 find_package(mins REQUIRED)
 
 add_definitions(-DROS_AVAILABLE=2)


### PR DESCRIPTION
ROS2 docker build was a no-op - colcon paths were relative to the wrong dir so it built 0 packages. Fixed the paths so the full workspace builds on Humble, plus a small mins_eval ros2 cmake fix (it links mins, which exports libpointmatcher, so that needs to be in scope). Added a ROS2 build workflow + badge to gate PRs on Humble. Compile-only for now, will add a sim smoke-run once the ros2 launch/config is wired up.