### PR TITLE
ros2: make simulation runnable + add smoke test to CI

### DIFF
--- a/.github/workflows/build_ros2.yml
+++ b/.github/workflows/build_ros2.yml
@@ -15,3 +15,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build the Docker image (Humble 22.04)
         run: docker build . --file Dockerfile_humble_22_04 --tag mins:humble
+      - name: Smoke test - simulation runs end to end
+        run: |
+          docker run --rm --entrypoint /bin/bash mins:humble -c '
+            set -eo pipefail
+            source /opt/ros/humble/setup.bash && source /work/install/setup.bash
+            cfg=/work/install/mins/share/mins/config/simulation/config.yaml
+            timeout 600 ros2 run mins simulation "$cfg" 2>&1 | tee /tmp/sim.log
+            grep -q "RMSE average" /tmp/sim.log
+          '

--- a/mins/launch/simulation.launch.py
+++ b/mins/launch/simulation.launch.py
@@ -1,0 +1,26 @@
+import launch
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    config_path = LaunchConfiguration("config_path")
+    default_config = PathJoinSubstitution(
+        [FindPackageShare("mins"), "config", "simulation", "config.yaml"]
+    )
+    return launch.LaunchDescription([
+        DeclareLaunchArgument(
+            "config_path",
+            default_value=default_config,
+            description="Path to the master MINS simulation config yaml",
+        ),
+        Node(
+            package="mins",
+            executable="simulation",
+            name="mins_simulation",
+            output="screen",
+            parameters=[{"config_path": config_path}],
+        ),
+    ])

--- a/mins/src/options/OptionsSimulation.cpp
+++ b/mins/src/options/OptionsSimulation.cpp
@@ -69,7 +69,7 @@ void mins::OptionsSimulation::load_print(const std::shared_ptr<ov_core::YamlPars
 #if ROS_AVAILABLE == 1
     auto dir = ros::package::getPath("mins_data");
 #elif ROS_AVAILABLE == 2
-    auto dir = ament_index_cpp::get_package_share_directory("mins");
+    auto dir = ament_index_cpp::get_package_share_directory("mins_data");
 #endif
     BSpline_path.substr(0, 13) == "MINS_DATA_DIR" ? BSpline_path.replace(0, 13, dir) : std::string();
     planes_path.substr(0, 13) == "MINS_DATA_DIR" ? planes_path.replace(0, 13, dir) : std::string();

--- a/mins/src/run_simulation.cpp
+++ b/mins/src/run_simulation.cpp
@@ -144,6 +144,10 @@ int main(int argc, char **argv) {
   save->check_files();
 
 #if ROS_AVAILABLE == 2
+  // Release publishers (and the node they hold) while the context is still
+  // valid, otherwise their rcl handles are destroyed after shutdown -> segfault.
+  pub.reset();
+  sim_viz.reset();
   rclcpp::shutdown();
 #endif
   return EXIT_SUCCESS;
@@ -160,6 +164,8 @@ void system_setup(int argc, char **argv) {
 
   auto node = std::make_shared<rclcpp::Node>("mins_simulation");
 
+  // Declare so the value can be supplied either via launch parameter or argv[1].
+  node->declare_parameter<std::string>("config_path", config_path);
   node->get_parameter<std::string>("config_path", config_path);
 #elif ROS_AVAILABLE == 1
   ros::init(argc, argv, "mins_simulation");

--- a/mins_data/CMakeLists.txt
+++ b/mins_data/CMakeLists.txt
@@ -11,6 +11,8 @@ if (catkin_FOUND)
     catkin_package()
 elseif (ament_cmake_FOUND)
     message(STATUS "ROS *2* version found")
+    install(DIRECTORY BSplineDataset FloorPlans GroundTruths
+            DESTINATION share/${PROJECT_NAME})
     ament_package()
 else ()
     message(STATUS "No ROS versions found, doing nothing...")


### PR DESCRIPTION
Builds on #61 (which fixed the ROS 2 colcon build). This makes the ROS 2 simulation actually run end to end, and upgrades the ROS 2 CI from compile-only to compile + smoke-run.

### Changes
- **mins_data**: install `BSplineDataset`/`FloorPlans`/`GroundTruths` into the ament share dir (previously the data was never installed for ROS 2).
- **OptionsSimulation**: on ROS 2 resolve `MINS_DATA_DIR` from the `mins_data` package share (was pointing at `mins`, where the data does not exist).
- **run_simulation**: `declare_parameter("config_path")` so launch files can set it (passing the path as `argv[1]` still works); reset the publishers before `rclcpp::shutdown()` to avoid a teardown segfault.
- **simulation.launch.py**: ROS 2 launch file (parity with the ROS 1 `simulation.launch`).
- **build_ros2.yml**: after the Humble image builds, run the default simulation to completion and assert it prints an RMSE summary.

### Verified locally (Humble 22.04)
- `ros2 run mins simulation <config.yaml>` -> exit 0, RMSE average 0.447 deg / 0.239 m.
- `ros2 launch mins simulation.launch.py` -> exit 0, produces RMSE.
- No more teardown segfault.