### PR TITLE
drop boost from mins, mins_eval and ov_core

### DIFF
--- a/Dockerfile_rosfree_ubuntu_22_04
+++ b/Dockerfile_rosfree_ubuntu_22_04
@@ -5,7 +5,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential cmake git ca-certificates \
-    libeigen3-dev libboost-all-dev libopencv-dev libpcl-dev libyaml-cpp-dev \
+    libeigen3-dev libopencv-dev libpcl-dev libyaml-cpp-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work

--- a/mins/CMakeLists.txt
+++ b/mins/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.5.1)
 # Project name
 project(mins)
 
-# We need c++14 for ROS2, thus just require it for everybody
+# We need c++17 for std::filesystem
 # NOTE: To future self, hope this isn't an issue...
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -25,8 +25,7 @@ find_package(OpenCV 4 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 3 REQUIRED QUIET)
 endif ()
-find_package(Boost REQUIRED QUIET COMPONENTS system filesystem thread date_time program_options chrono)
-message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION})
+message(STATUS "OPENCV: " ${OpenCV_VERSION})
 message(STATUS "Eigen3: " ${Eigen3_VERSION} " | PCL: " ${PCL_VERSION})
 
 # Enable compile optimizations
@@ -34,6 +33,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-sign
 
 # Enable debug flags (use if you want to debug in gdb)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
+
+# GCC older than 9.1 needs an explicit lib for std::filesystem (ROS Melodic ships GCC 7.5)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
+    list(APPEND thirdparty_libraries stdc++fs)
+endif ()
 
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)

--- a/mins/cmake/ROS1.cmake
+++ b/mins/cmake/ROS1.cmake
@@ -16,12 +16,10 @@ endif ()
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
 )
 
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
-        ${Boost_LIBRARIES}
         ${OpenCV_LIBRARIES}
         )
 

--- a/mins/cmake/ROS2.cmake
+++ b/mins/cmake/ROS2.cmake
@@ -49,12 +49,10 @@ list(APPEND ament_libraries
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
 )
 
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
-        ${Boost_LIBRARIES}
         ${OpenCV_LIBRARIES}
         ${PCL_LIBRARIES}
         )

--- a/mins/src/core/SystemManager.h
+++ b/mins/src/core/SystemManager.h
@@ -29,7 +29,6 @@
 #define MINS_SYSTEMMANAGER_H
 
 #include <Eigen/Eigen>
-#include <boost/shared_ptr.hpp>
 #include <memory>
 
 namespace pcl {

--- a/mins/src/options/Options.cpp
+++ b/mins/src/options/Options.cpp
@@ -27,6 +27,7 @@
 #include "OptionsVicon.h"
 #include "OptionsWheel.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 mins::Options::Options() {
@@ -42,7 +43,7 @@ void mins::Options::load_print(const std::shared_ptr<ov_core::YamlParser> &parse
   sim->load_print(parser);
 
   // force nonholonomic constraint to simulated trajectory when using wheel measurements
-  if (est->wheel->enabled && sim->const_holonomic && boost::filesystem::exists(parser->get_config_folder() + "config_simulation.yaml")) {
+  if (est->wheel->enabled && sim->const_holonomic && fs::exists(parser->get_config_folder() + "config_simulation.yaml")) {
     PRINT3(YELLOW "Enable non-holonomic constraint for wheel simulation.\n" RESET);
     sim->const_holonomic = false;
   }

--- a/mins/src/options/OptionsCamera.cpp
+++ b/mins/src/options/OptionsCamera.cpp
@@ -28,12 +28,13 @@
 #include "OptionsCamera.h"
 #include "feat/FeatureInitializerOptions.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 void mins::OptionsCamera::load(const std::shared_ptr<ov_core::YamlParser> &parser) {
   if (parser != nullptr) {
     std::string f = "config_camera";
-    if (!boost::filesystem::exists(parser->get_config_folder() + f + ".yaml")) {
+    if (!fs::exists(parser->get_config_folder() + f + ".yaml")) {
       enabled = false;
       return;
     }
@@ -190,7 +191,7 @@ void mins::OptionsCamera::load_i(const std::shared_ptr<ov_core::YamlParser> &par
     std::string mask_node = "mask" + std::to_string(i);
     parser->parse_external(f, "cam" + std::to_string(i), "mask", mask_path);
     std::string total_mask_path = parser->get_config_folder() + mask_path;
-    if (!boost::filesystem::exists(total_mask_path)) {
+    if (!fs::exists(total_mask_path)) {
       PRINT4(RED "VioManager(): invalid mask path:\n" RESET);
       PRINT4(RED "\t- mask%d - %s\n" RESET, i, total_mask_path.c_str());
       std::exit(EXIT_FAILURE);

--- a/mins/src/options/OptionsGPS.cpp
+++ b/mins/src/options/OptionsGPS.cpp
@@ -20,12 +20,13 @@
 
 #include "OptionsGPS.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 void mins::OptionsGPS::load(const std::shared_ptr<ov_core::YamlParser> &parser) {
   if (parser != nullptr) {
     std::string f = "config_gps";
-    if (!boost::filesystem::exists(parser->get_config_folder() + f + ".yaml")) {
+    if (!fs::exists(parser->get_config_folder() + f + ".yaml")) {
       enabled = false;
       return;
     }

--- a/mins/src/options/OptionsLidar.cpp
+++ b/mins/src/options/OptionsLidar.cpp
@@ -20,12 +20,13 @@
 
 #include "OptionsLidar.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 void mins::OptionsLidar::load(const std::shared_ptr<ov_core::YamlParser> &parser) {
   if (parser != nullptr) {
     std::string f = "config_lidar";
-    if (!boost::filesystem::exists(parser->get_config_folder() + f + ".yaml")) {
+    if (!fs::exists(parser->get_config_folder() + f + ".yaml")) {
       enabled = false;
       return;
     }

--- a/mins/src/options/OptionsSimulation.cpp
+++ b/mins/src/options/OptionsSimulation.cpp
@@ -29,6 +29,7 @@
 #include "OptionsEstimator.h"
 #include "utils/PackagePath.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 mins::OptionsSimulation::OptionsSimulation() { est_true = std::make_shared<OptionsEstimator>(); }
@@ -36,7 +37,7 @@ mins::OptionsSimulation::OptionsSimulation() { est_true = std::make_shared<Optio
 void mins::OptionsSimulation::load_print(const std::shared_ptr<ov_core::YamlParser> &parser) {
   if (parser != nullptr) {
     std::string f = "config_simulation";
-    if (!boost::filesystem::exists(parser->get_config_folder() + f + ".yaml")) {
+    if (!fs::exists(parser->get_config_folder() + f + ".yaml")) {
       return;
     }
     parser->parse_external(f, "sim", "seed", seed);

--- a/mins/src/options/OptionsVicon.cpp
+++ b/mins/src/options/OptionsVicon.cpp
@@ -20,12 +20,13 @@
 
 #include "OptionsVicon.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 void mins::OptionsVicon::load(const std::shared_ptr<ov_core::YamlParser> &parser) {
   if (parser != nullptr) {
     std::string f = "config_vicon";
-    if (!boost::filesystem::exists(parser->get_config_folder() + f + ".yaml")) {
+    if (!fs::exists(parser->get_config_folder() + f + ".yaml")) {
       enabled = false;
       return;
     }

--- a/mins/src/options/OptionsWheel.cpp
+++ b/mins/src/options/OptionsWheel.cpp
@@ -20,12 +20,13 @@
 
 #include "OptionsWheel.h"
 #include "utils/Print_Logger.h"
+#include "utils/fs_compat.h"
 #include "utils/opencv_yaml_parse.h"
 
 void mins::OptionsWheel::load(const std::shared_ptr<ov_core::YamlParser> &parser) {
   if (parser != nullptr) {
     std::string f = "config_wheel";
-    if (!boost::filesystem::exists(parser->get_config_folder() + f + ".yaml")) {
+    if (!fs::exists(parser->get_config_folder() + f + ".yaml")) {
       enabled = false;
       return;
     }

--- a/mins/src/sim/Simulator.h
+++ b/mins/src/sim/Simulator.h
@@ -29,7 +29,6 @@
 #define MINS_SIMULATOR_H
 
 #include <Eigen/Eigen>
-#include <boost/shared_ptr.hpp>
 #include <memory>
 #include <random>
 #include <unordered_map>

--- a/mins/src/state/StateHelper.cpp
+++ b/mins/src/state/StateHelper.cpp
@@ -35,8 +35,8 @@
 #include "types/PoseJPL.h"
 #include "types/Type.h"
 #include "utils/Print_Logger.h"
+#include "utils/chi_square.h"
 #include "utils/colors.h"
-#include <boost/math/distributions/chi_squared.hpp>
 
 using namespace ov_core;
 using namespace ov_type;
@@ -436,8 +436,7 @@ bool StateHelper::initialize(shared_ptr<State> state, shared_ptr<Type> new_varia
     double chi2 = resup.transpose() * S.inverse().selfadjointView<Upper>() * resup;
 
     // Get what our threshold should be
-    boost::math::chi_squared chi_squared_dist(res.rows());
-    double chi2_check = boost::math::quantile(chi_squared_dist, 0.95);
+    double chi2_check = chi_square_quantile(0.95, res.rows());
     if (chi2 > chi_2_mult * chi2_check) {
       return false;
     }

--- a/mins/src/update/UpdaterStatistics.cpp
+++ b/mins/src/update/UpdaterStatistics.cpp
@@ -23,14 +23,13 @@
 #include "state/StateHelper.h"
 #include "utils/Jabdongsani.h"
 #include "utils/Print_Logger.h"
-#include <boost/math/distributions/chi_squared.hpp>
+#include "utils/chi_square.h"
 
-using namespace boost::math;
 using namespace mins;
 
 UpdaterStatistics::UpdaterStatistics(double chi2_mult, string type, int id) : type(type), id(id), chi2_mult(chi2_mult) {
   for (int i = 1; i < max_chi_size; i++)
-    chi_squared_table[i] = quantile(chi_squared(i), 0.95);
+    chi_squared_table[i] = chi_square_quantile(0.95, i);
   chi_stat = make_shared<STAT>();
   res_stat = make_shared<STAT>();
   std_stat = make_shared<STAT>();
@@ -111,8 +110,7 @@ bool UpdaterStatistics::get_chi2(double &chi, double &thr, const MatrixXd &P, co
   if (res.rows() < max_chi_size) {
     thr = chi2_mult * chi_squared_table[res.rows()];
   } else {
-    chi_squared chi_squared_dist(res.rows());
-    thr = chi2_mult * quantile(chi_squared_dist, 0.95);
+    thr = chi2_mult * chi_square_quantile(0.95, res.rows());
   }
   if (isnan(chi)) {
     string sensor = type + (id < 0 ? "" : to_string(id));

--- a/mins/src/update/gps/MathGPS.h
+++ b/mins/src/update/gps/MathGPS.h
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <complex>
 #include <numeric>
+#include <random>
 
 using namespace std;
 using namespace Eigen;
@@ -187,10 +188,10 @@ private:
   // Get random subsets of given sets
   static void get_random_subset(vector<Vector3d> &p_A, vector<Vector3d> &p_B, vector<Vector3d> &suBp_A, vector<Vector3d> &suBp_B, size_t sizeSubset) {
 
-    srand(1337);
+    mt19937 rng(1337);
     vector<unsigned int> indices(p_A.size());
     iota(indices.begin(), indices.end(), 0);
-    random_shuffle(indices.begin(), indices.end());
+    shuffle(indices.begin(), indices.end(), rng);
     for (size_t i = 0; i < sizeSubset; i++) {
       suBp_A.push_back(p_A[indices[i]]);
       suBp_B.push_back(p_B[indices[i]]);

--- a/mins/src/update/lidar/LidarTypes.h
+++ b/mins/src/update/lidar/LidarTypes.h
@@ -22,7 +22,7 @@
 #define MINS_LIDARTYPES_H
 
 #include <Eigen/Eigen>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using namespace Eigen;
 namespace pcl {

--- a/mins/src/update/lidar/UpdaterLidar.h
+++ b/mins/src/update/lidar/UpdaterLidar.h
@@ -22,7 +22,7 @@
 #define MINS_UPDATERLIDAR_H
 
 #include <Eigen/Eigen>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <queue>
 #include <unordered_map>
 #include <vector>

--- a/mins/src/utils/Print_Logger.cpp
+++ b/mins/src/utils/Print_Logger.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "Print_Logger.h"
-#include <boost/filesystem.hpp>
+#include "utils/fs_compat.h"
 #include <cstdarg>
 #include <cstring>
 #include <iostream>
@@ -42,16 +42,16 @@ void Print_Logger::open_file(const std::string &path, bool remove_exist) {
   std::string output_path;
   for (int i = 0; i < 10000; i++) {
     output_path = path + "/mins_log" + std::to_string(i) + ".txt";
-    if (boost::filesystem::exists(output_path)) {
+    if (fs::exists(output_path)) {
       if (remove_exist) {
-        boost::filesystem::remove(output_path);
+        fs::remove(output_path);
         break;
       }
       continue;
     } else
       break;
   }
-  boost::filesystem::create_directories(boost::filesystem::path(output_path.c_str()).parent_path());
+  fs::create_directories(fs::path(output_path.c_str()).parent_path());
   pFile = fopen(output_path.c_str(), "w");
 }
 

--- a/mins/src/utils/State_Logger.h
+++ b/mins/src/utils/State_Logger.h
@@ -28,8 +28,6 @@
 #ifndef MINS_LOGGER_H
 #define MINS_LOGGER_H
 
-#include "boost/filesystem/fstream.hpp"
-#include "boost/filesystem/operations.hpp"
 #include "options/Options.h"
 #include "options/OptionsCamera.h"
 #include "options/OptionsEstimator.h"
@@ -45,6 +43,8 @@
 #include "types/PoseJPL.h"
 #include "update/gps/UpdaterGPS.h"
 #include "utils/colors.h"
+#include "utils/fs_compat.h"
+#include <fstream>
 
 using namespace std;
 using namespace Eigen;
@@ -167,14 +167,14 @@ public:
       for (auto pair : filepath_est) {
         string sensor = pair.first;
         // If the files exist, then delete it
-        boost::filesystem::exists(filepath_est.at(sensor)) && boost::filesystem::remove(filepath_est.at(sensor));
-        boost::filesystem::exists(filepath_std.at(sensor)) && boost::filesystem::remove(filepath_std.at(sensor));
-        boost::filesystem::exists(filepath_gth.at(sensor)) && boost::filesystem::remove(filepath_gth.at(sensor));
+        fs::exists(filepath_est.at(sensor)) && fs::remove(filepath_est.at(sensor));
+        fs::exists(filepath_std.at(sensor)) && fs::remove(filepath_std.at(sensor));
+        fs::exists(filepath_gth.at(sensor)) && fs::remove(filepath_gth.at(sensor));
 
         // Create folder path to this location if not exists
-        boost::filesystem::create_directories(boost::filesystem::path(filepath_est.at(sensor).c_str()).parent_path());
-        boost::filesystem::create_directories(boost::filesystem::path(filepath_std.at(sensor).c_str()).parent_path());
-        boost::filesystem::create_directories(boost::filesystem::path(filepath_gth.at(sensor).c_str()).parent_path());
+        fs::create_directories(fs::path(filepath_est.at(sensor).c_str()).parent_path());
+        fs::create_directories(fs::path(filepath_std.at(sensor).c_str()).parent_path());
+        fs::create_directories(fs::path(filepath_gth.at(sensor).c_str()).parent_path());
 
         // Open the files
         shared_ptr<ofstream> of_est_tmp = make_shared<ofstream>();
@@ -212,8 +212,8 @@ public:
     // trajectory
     if (op->sys->save_trajectory) {
       // Create folder path to this location if not exists
-      boost::filesystem::exists(op->sys->path_trajectory.c_str()) && boost::filesystem::remove(op->sys->path_trajectory.c_str());
-      boost::filesystem::create_directories(boost::filesystem::path(op->sys->path_trajectory.c_str()).parent_path());
+      fs::exists(op->sys->path_trajectory.c_str()) && fs::remove(op->sys->path_trajectory.c_str());
+      fs::create_directories(fs::path(op->sys->path_trajectory.c_str()).parent_path());
       of_traj.open(op->sys->path_trajectory.c_str());
       if (!of_traj.is_open()) {
         PRINT4(RED "Cannot open trajectory recording file: %s\n" RESET, op->sys->path_trajectory.c_str());
@@ -226,8 +226,8 @@ public:
     // Time
     if (op->sys->save_timing) {
       // Create folder path to this location if not exists
-      boost::filesystem::exists(op->sys->path_timing.c_str()) && boost::filesystem::remove(op->sys->path_timing.c_str());
-      boost::filesystem::create_directories(boost::filesystem::path(op->sys->path_timing.c_str()).parent_path());
+      fs::exists(op->sys->path_timing.c_str()) && fs::remove(op->sys->path_timing.c_str());
+      fs::create_directories(fs::path(op->sys->path_timing.c_str()).parent_path());
       of_time.open(op->sys->path_timing.c_str());
       if (!of_time.is_open()) {
         PRINT4(RED "Cannot open timing recording file: %s\n" RESET, op->sys->path_timing.c_str());
@@ -353,20 +353,20 @@ public:
       for (auto pair : filepath_est) {
         string sensor = pair.first;
         // If the files exist, then delete it
-        boost::filesystem::exists(filepath_est.at(sensor)) && boost::filesystem::remove(filepath_est.at(sensor));
-        boost::filesystem::exists(filepath_std.at(sensor)) && boost::filesystem::remove(filepath_std.at(sensor));
-        boost::filesystem::exists(filepath_gth.at(sensor)) && boost::filesystem::remove(filepath_gth.at(sensor));
+        fs::exists(filepath_est.at(sensor)) && fs::remove(filepath_est.at(sensor));
+        fs::exists(filepath_std.at(sensor)) && fs::remove(filepath_std.at(sensor));
+        fs::exists(filepath_gth.at(sensor)) && fs::remove(filepath_gth.at(sensor));
       }
     }
 
     // Trajectory
     if (op->sys->save_trajectory && (total_t < 0 || cnt_traj == 0)) {
-      boost::filesystem::exists(op->sys->path_trajectory.c_str()) && boost::filesystem::remove(op->sys->path_trajectory.c_str());
+      fs::exists(op->sys->path_trajectory.c_str()) && fs::remove(op->sys->path_trajectory.c_str());
     }
 
     // Time
     if (op->sys->save_timing && (total_t < 0 || cnt_time == 0 || (cnt_state == 0 && cnt_traj == 0))) {
-      boost::filesystem::exists(op->sys->path_timing.c_str()) && boost::filesystem::remove(op->sys->path_timing.c_str());
+      fs::exists(op->sys->path_timing.c_str()) && fs::remove(op->sys->path_timing.c_str());
     }
   }
 

--- a/mins/src/utils/TimeChecker.h
+++ b/mins/src/utils/TimeChecker.h
@@ -21,8 +21,8 @@
 #ifndef MINS_TIMECHECKER_H
 #define MINS_TIMECHECKER_H
 
-#include "boost/date_time/posix_time/posix_time.hpp"
 #include "utils/Print_Logger.h"
+#include <chrono>
 #include <map>
 #include <string>
 #include <vector>
@@ -54,8 +54,8 @@ public:
 
   /// Struct carry time ding dong information
   struct record {
-    boost::posix_time::ptime ding_t;
-    boost::posix_time::ptime dong_t;
+    std::chrono::steady_clock::time_point ding_t;
+    std::chrono::steady_clock::time_point dong_t;
     bool has_prev_ding = false;
     double total_t = 0;
     double max_t = -INFINITY;
@@ -67,7 +67,7 @@ public:
     if (names.find(name) == names.end())
       names.insert({name, record()});
 
-    names.at(name).ding_t = boost::posix_time::microsec_clock::local_time();
+    names.at(name).ding_t = std::chrono::steady_clock::now();
     names.at(name).has_prev_ding = true;
   }
 
@@ -75,7 +75,7 @@ public:
   void ding() {
     // Should have a name
     assert(names.size() == 1);
-    names.begin()->second.ding_t = boost::posix_time::microsec_clock::local_time();
+    names.begin()->second.ding_t = std::chrono::steady_clock::now();
     names.begin()->second.has_prev_ding = true;
   }
 
@@ -85,8 +85,8 @@ public:
       PRINT3("[TimeChecker] Cannot dong because no ding for this name(%s) setup!\n", name.c_str());
       return;
     }
-    names.at(name).dong_t = boost::posix_time::microsec_clock::local_time();
-    double dt = (double)((names.at(name).dong_t - names.at(name).ding_t).total_microseconds() * 1e-6);
+    names.at(name).dong_t = std::chrono::steady_clock::now();
+    double dt = std::chrono::duration<double>(names.at(name).dong_t - names.at(name).ding_t).count();
     names.at(name).total_t += dt;
     if (dt > names.at(name).max_t)
       names.at(name).max_t = dt;
@@ -97,8 +97,8 @@ public:
   void dong() {
     // Should have a name
     assert(names.size() == 1);
-    names.begin()->second.dong_t = boost::posix_time::microsec_clock::local_time();
-    double dt = (double)((names.begin()->second.dong_t - names.begin()->second.ding_t).total_microseconds() * 1e-6);
+    names.begin()->second.dong_t = std::chrono::steady_clock::now();
+    double dt = std::chrono::duration<double>(names.begin()->second.dong_t - names.begin()->second.ding_t).count();
     names.begin()->second.total_t += dt;
     if (dt > names.begin()->second.max_t)
       names.begin()->second.max_t = dt;
@@ -110,22 +110,22 @@ public:
     // if cannot find this name, append to the map
     if (names.find(name) == names.end()) {
       names.insert({name, record()});
-      names.at(name).ding_t = boost::posix_time::microsec_clock::local_time();
+      names.at(name).ding_t = std::chrono::steady_clock::now();
       names.at(name).has_prev_ding = true;
       return;
     }
 
     // Do ding if we dont have prev ding
     if (!names.at(name).has_prev_ding) {
-      names.at(name).ding_t = boost::posix_time::microsec_clock::local_time();
+      names.at(name).ding_t = std::chrono::steady_clock::now();
       names.at(name).has_prev_ding = true;
       return;
     }
 
     // Do dong if we have prev ding
     if (names.at(name).has_prev_ding) {
-      names.at(name).dong_t = boost::posix_time::microsec_clock::local_time();
-      double dt = (double)((names.at(name).dong_t - names.at(name).ding_t).total_microseconds() * 1e-6);
+      names.at(name).dong_t = std::chrono::steady_clock::now();
+      double dt = std::chrono::duration<double>(names.at(name).dong_t - names.at(name).ding_t).count();
       names.at(name).total_t += dt;
       if (dt > names.at(name).max_t)
         names.at(name).max_t = dt;

--- a/mins/src/utils/chi_square.h
+++ b/mins/src/utils/chi_square.h
@@ -1,0 +1,96 @@
+/*
+ * MINS: Efficient and Robust Multisensor-aided Inertial Navigation System
+ * Copyright (C) 2023 Woosik Lee
+ * Copyright (C) 2023 Guoquan Huang
+ * Copyright (C) 2023 MINS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MINS_CHI_SQUARE_H
+#define MINS_CHI_SQUARE_H
+
+#include <cmath>
+
+namespace mins {
+
+/// Regularized lower incomplete gamma P(a,x). Series below a+1, continued fraction above.
+inline double gamma_p(double a, double x) {
+  if (x <= 0.0)
+    return 0.0;
+  double gln = std::lgamma(a);
+  if (x < a + 1.0) {
+    // series representation
+    double ap = a, del = 1.0 / a, sum = del;
+    for (int n = 0; n < 500; n++) {
+      ap += 1.0;
+      del *= x / ap;
+      sum += del;
+      if (std::fabs(del) < std::fabs(sum) * 1e-16)
+        break;
+    }
+    return sum * std::exp(-x + a * std::log(x) - gln);
+  }
+  // continued fraction for the upper Q(a,x), then P = 1 - Q (Lentz)
+  double b = x + 1.0 - a, c = 1e300, d = 1.0 / b, h = d;
+  for (int i = 1; i < 500; i++) {
+    double an = -i * (i - a);
+    b += 2.0;
+    d = an * d + b;
+    if (std::fabs(d) < 1e-300)
+      d = 1e-300;
+    c = b + an / c;
+    if (std::fabs(c) < 1e-300)
+      c = 1e-300;
+    d = 1.0 / d;
+    double del = d * c;
+    h *= del;
+    if (std::fabs(del - 1.0) < 1e-16)
+      break;
+  }
+  return 1.0 - std::exp(-x + a * std::log(x) - gln) * h;
+}
+
+/// chi-square CDF with k degrees of freedom.
+inline double chi_square_cdf(double x, double k) { return gamma_p(0.5 * k, 0.5 * x); }
+
+/// Inverse chi-square CDF: the x where P(chi2_k <= x) = p. Replaces boost::math::quantile(chi_squared(k), p).
+/// Safeguarded Newton (bisection fallback) on the CDF -- robust for any k, converges in ~10 iters.
+inline double chi_square_quantile(double p, double k) {
+  if (p <= 0.0)
+    return 0.0;
+  // bracket the root by expanding from the mean (= k)
+  double lo = 0.0, hi = (k > 0.0 ? k : 1.0);
+  while (chi_square_cdf(hi, k) < p)
+    hi *= 2.0;
+  double x = 0.5 * (lo + hi);
+  double lngam = std::lgamma(0.5 * k);
+  for (int i = 0; i < 200; i++) {
+    double err = chi_square_cdf(x, k) - p;
+    (err > 0.0 ? hi : lo) = x;
+    // chi-square pdf; Newton step only if it stays inside the bracket
+    double pdf = std::exp((0.5 * k - 1.0) * std::log(x) - 0.5 * x - 0.5 * k * M_LN2 - lngam);
+    double next = (pdf > 0.0) ? x - err / pdf : 0.5 * (lo + hi);
+    if (!(next > lo && next < hi))
+      next = 0.5 * (lo + hi);
+    if (std::fabs(next - x) < 1e-13 * std::fabs(x))
+      return next;
+    x = next;
+  }
+  return x;
+}
+
+} // namespace mins
+
+#endif // MINS_CHI_SQUARE_H

--- a/mins/src/utils/fs_compat.h
+++ b/mins/src/utils/fs_compat.h
@@ -1,0 +1,33 @@
+/*
+ * MINS: Efficient and Robust Multisensor-aided Inertial Navigation System
+ * Copyright (C) 2023 Woosik Lee
+ * Copyright (C) 2023 Guoquan Huang
+ * Copyright (C) 2023 MINS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MINS_FS_COMPAT_H
+#define MINS_FS_COMPAT_H
+
+// GCC 7 (ROS Melodic) ships filesystem only under <experimental/>. Everything newer has <filesystem>.
+#if defined(__has_include) && __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#endif // MINS_FS_COMPAT_H

--- a/mins_eval/CMakeLists.txt
+++ b/mins_eval/CMakeLists.txt
@@ -5,7 +5,6 @@ project(mins_eval)
 
 # Include libraries
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
 
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
 
@@ -24,9 +23,9 @@ if (Python_FOUND AND NOT DISABLE_MATPLOTLIB)
     list(APPEND thirdparty_libraries ${Python_LIBRARIES})
 endif ()
 
-# We need c++14 for ROS2, thus just require it for everybody
+# We need c++17 for std::filesystem
 # NOTE: To future self, hope this isn't an issue...
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -38,6 +37,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninit
 
 find_package(PCL REQUIRED QUIET)
 # Find ROS build system
+
+# GCC older than 9.1 needs an explicit lib for std::filesystem (ROS Melodic ships GCC 7.5)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
+    list(APPEND thirdparty_libraries stdc++fs)
+endif ()
 
 find_package(catkin QUIET COMPONENTS roscpp)
 find_package(ament_cmake QUIET)

--- a/mins_eval/cmake/ROS1.cmake
+++ b/mins_eval/cmake/ROS1.cmake
@@ -12,7 +12,6 @@ catkin_package(
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
         ${PCL_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}
@@ -20,7 +19,6 @@ include_directories(
 
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
-        ${Boost_LIBRARIES}
         ${catkin_LIBRARIES}
         )
 

--- a/mins_eval/cmake/ROS2.cmake
+++ b/mins_eval/cmake/ROS2.cmake
@@ -32,13 +32,11 @@ list(APPEND ament_libraries
 # Include our header files
 include_directories(
         ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
 )
 
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
-        ${Boost_LIBRARIES}
         )
 
 ##################################################

--- a/mins_eval/src/plot_consistency.cpp
+++ b/mins_eval/src/plot_consistency.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "functions/ErrorPlot.h"
+#include "utils/fs_compat.h"
 
 #if ROS_AVAILABLE == 2
 #include "rclcpp/rclcpp.hpp"
@@ -78,7 +79,7 @@ int main(int argc, char **argv) {
   if (argc > 2)
     save_path = argv[2];
   save_path += save_path.back() != '/' ? "/" : "";
-  boost::filesystem::create_directories(save_path.c_str());
+  fs::create_directories(save_path.c_str());
 
   // Create our trajectory object
   mins_eval::ErrorPlot traj(load_path, save_path);

--- a/mins_eval/src/run_comparison.cpp
+++ b/mins_eval/src/run_comparison.cpp
@@ -32,9 +32,8 @@
 #include "ros/ros.h"
 #endif
 #include "utils/Loader.h"
+#include "utils/fs_compat.h"
 #include <Eigen/Eigen>
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <map>
 #include <string>
 #include <utility>
@@ -42,9 +41,15 @@
 
 using namespace std;
 using namespace ov_eval;
-using namespace boost;
 using namespace Eigen;
-typedef boost::filesystem::path PATH;
+typedef fs::path PATH;
+// replace_all_copy was the only boost::algorithm function we used
+static string replace_all_copy(string s, const string &from, const string &to) {
+  for (size_t i = s.find(from); i != string::npos; i = s.find(from, i + to.size()))
+    s.replace(i, from.size(), to);
+  return s;
+}
+
 typedef vector<PATH> VEC_PATH;
 // file and directory paths
 string align_mode, folder_groundtruths, folder_algorithms;
@@ -242,7 +247,7 @@ void basic_setup(int argc, char **argv) {
 /// Get paths of the ground truths
 VEC_PATH get_path_groundtruths() {
   VEC_PATH path_gts_local;
-  for (const auto &p : boost::filesystem::recursive_directory_iterator(folder_groundtruths)) {
+  for (const auto &p : fs::recursive_directory_iterator(folder_groundtruths)) {
     if (p.path().extension() == ".txt") {
       path_gts_local.push_back(p.path());
     }
@@ -267,8 +272,8 @@ VEC_PATH get_path_groundtruths() {
 VEC_PATH get_path_algorithms() {
   // Also create empty statistic objects for each of our datasets
   VEC_PATH path_alg;
-  for (const auto &entry : boost::filesystem::directory_iterator(folder_algorithms)) {
-    if (boost::filesystem::is_directory(entry)) {
+  for (const auto &entry : fs::directory_iterator(folder_algorithms)) {
+    if (fs::is_directory(entry)) {
       path_alg.push_back(entry.path());
     }
   }
@@ -280,8 +285,8 @@ VEC_PATH get_path_algorithms() {
   for (auto &path : path_alg) {
     // Get the list of datasets this algorithm records
     map<string, PATH> path_algo_datasets;
-    for (auto &entry : boost::filesystem::directory_iterator(path)) {
-      if (boost::filesystem::is_directory(entry)) {
+    for (auto &entry : fs::directory_iterator(path)) {
+      if (fs::is_directory(entry)) {
         found_data.push_back(entry.path().filename().string());
         path_algo_datasets.insert({entry.path().filename().string(), entry.path()});
       }
@@ -379,8 +384,8 @@ map<string, map<PATH, pair<Statistics, Statistics>>> NEES_init() {
 /// Get files given directory path
 map<string, PATH> get_list_of_datasets(const PATH &path) {
   map<string, PATH> path_algo_datasets;
-  for (auto &entry : boost::filesystem::directory_iterator(path)) {
-    if (boost::filesystem::is_directory(entry)) {
+  for (auto &entry : fs::directory_iterator(path)) {
+    if (fs::is_directory(entry)) {
       path_algo_datasets.insert({entry.path().filename().string(), entry.path()});
     }
   }
@@ -389,7 +394,7 @@ map<string, PATH> get_list_of_datasets(const PATH &path) {
 
 /// search for specific extentioned files for analysis.
 void get_paths_of_run_files(map<string, PATH> datasets, const PATH &path_gt, vector<string> &run_paths, vector<string> &time_paths) {
-  for (auto &entry : boost::filesystem::directory_iterator(datasets.at(path_gt.stem().string()))) {
+  for (auto &entry : fs::directory_iterator(datasets.at(path_gt.stem().string()))) {
     // Files containing timing record
     if (entry.path().extension() == ".time") {
       time_paths.push_back(entry.path().string());

--- a/mins_eval/src/utils/fs_compat.h
+++ b/mins_eval/src/utils/fs_compat.h
@@ -1,0 +1,33 @@
+/*
+ * MINS: Efficient and Robust Multisensor-aided Inertial Navigation System
+ * Copyright (C) 2023 Woosik Lee
+ * Copyright (C) 2023 Guoquan Huang
+ * Copyright (C) 2023 MINS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MINS_EVAL_FS_COMPAT_H
+#define MINS_EVAL_FS_COMPAT_H
+
+// GCC 7 (ROS Melodic) ships filesystem only under <experimental/>. Everything newer has <filesystem>.
+#if defined(__has_include) && __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#endif // MINS_EVAL_FS_COMPAT_H

--- a/thirdparty/open_vins/ov_core/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_core/CMakeLists.txt
@@ -8,8 +8,7 @@ find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
     find_package(OpenCV 4 REQUIRED)
 endif ()
-find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
-message(STATUS "OPENCV: " ${OpenCV_VERSION} " | BOOST: " ${Boost_VERSION})
+message(STATUS "OPENCV: " ${OpenCV_VERSION})
 
 # If we will compile with aruco support
 option(ENABLE_ARUCO_TAGS "Enable or disable aruco tag (disable if no contrib modules)" ON)

--- a/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
@@ -25,13 +25,11 @@ endif ()
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}
 )
 
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
-        ${Boost_LIBRARIES}
         ${OpenCV_LIBRARIES}
         ${catkin_LIBRARIES}
 )

--- a/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
@@ -16,12 +16,10 @@ add_definitions(-DROS_AVAILABLE=2)
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
 )
 
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
-        ${Boost_LIBRARIES}
         ${OpenCV_LIBRARIES}
 )
 

--- a/thirdparty/open_vins/ov_core/package.xml
+++ b/thirdparty/open_vins/ov_core/package.xml
@@ -37,7 +37,6 @@
     <depend>eigen</depend>
     <depend>libopencv-dev</depend>
     <depend>libopencv-contrib-dev</depend>
-    <depend>boost</depend>
 
     <!-- Note the export is required to expose the executables -->
     <export>

--- a/thirdparty/open_vins/ov_core/src/test_profile.cpp
+++ b/thirdparty/open_vins/ov_core/src/test_profile.cpp
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
 #include <cmath>
 #include <sstream>
 #include <unistd.h>
@@ -28,8 +29,6 @@
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/opencv.hpp>
-
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "utils/print.h"
 
@@ -97,10 +96,10 @@ int main(int argc, char **argv) {
   // OPENCV: RANDOM BIG IMAGE
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     cv::randu(img3, cv::Scalar(0, 0, 0), cv::Scalar(255, 255, 255));
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("OPENCV: RANDOM BIG IMAGE", times_ms);
 
@@ -108,10 +107,10 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     cv::randu(img1, cv::Scalar(0), cv::Scalar(255));
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     cv::equalizeHist(img1, img1);
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("OPENCV: HISTOGRAM EQUALIZATION", times_ms);
 
@@ -119,11 +118,11 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     cv::randu(img1, cv::Scalar(0), cv::Scalar(255));
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     std::vector<cv::Mat> imgpyr;
     cv::buildOpticalFlowPyramid(img1, imgpyr, win_size, pyr_levels);
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("OPENCV: BUILD OPTICAL FLOW PYRAMID", times_ms);
 
@@ -132,11 +131,11 @@ int main(int argc, char **argv) {
   extra_stats.clear();
   for (int i = 0; i < num_trials; i++) {
     cv::randu(img1, cv::Scalar(0), cv::Scalar(255));
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     std::vector<cv::KeyPoint> pts_new;
     cv::FAST(img1, pts_new, fast_threshold, true);
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
     extra_stats.push_back((int)pts_new.size());
   }
   print_stats("OPENCV: FAST FEATURE EXTRACTION", times_ms, "feats", extra_stats);
@@ -155,7 +154,7 @@ int main(int argc, char **argv) {
       pts0.push_back(pts0_tmp.at(j).pt);
     cv::randu(img1, cv::Scalar(0), cv::Scalar(255)); // second image
     cv::buildOpticalFlowPyramid(img1, imgpyr2, win_size, pyr_levels);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     std::vector<uchar> mask_klt;
     std::vector<float> error;
     std::vector<cv::Point2f> pts1, pts1_good;
@@ -164,8 +163,8 @@ int main(int argc, char **argv) {
       if (mask_klt.at(j))
         pts1_good.push_back(pts1.at(j));
     }
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
     extra_stats.push_back((int)pts1_good.size());
   }
   print_stats("OPENCV: KLT OPTICAL FLOW", times_ms, "feats", extra_stats);
@@ -177,11 +176,11 @@ int main(int argc, char **argv) {
   // EIGEN3(double): RANDOM BIG MATRIX
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(big_matrix_eigen1, big_matrix_eigen1);
     Eigen::MatrixXd mat2 = Eigen::MatrixXd::Random(big_matrix_eigen1, big_matrix_eigen1);
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(double): RANDOM BIG MATRIX", times_ms);
 
@@ -190,10 +189,10 @@ int main(int argc, char **argv) {
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(big_matrix_eigen1, big_matrix_eigen1);
     Eigen::MatrixXd mat2 = Eigen::MatrixXd::Random(big_matrix_eigen1, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXd mat3 = mat1 * mat2;
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(double): MATRIX MULTIPLY", times_ms);
 
@@ -201,10 +200,10 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(big_matrix_eigen1, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     mat1 = mat1.inverse();
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(double): MATRIX INVERSION", times_ms);
 
@@ -212,10 +211,10 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(big_matrix_eigen2, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXd QR = mat1.householderQr().matrixQR();
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(double): HOUSEHOLDER QR FULL", times_ms);
 
@@ -223,10 +222,10 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(big_matrix_eigen2, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXd R = mat1.colPivHouseholderQr().matrixR();
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(double): HOUSEHOLDER QR PIV", times_ms);
 
@@ -236,15 +235,15 @@ int main(int argc, char **argv) {
     Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(big_matrix_eigen2, big_matrix_eigen1);
     Eigen::VectorXd tempV1 = Eigen::VectorXd::Zero(big_matrix_eigen2 * big_matrix_eigen1, 1);
     Eigen::VectorXd tempV2;
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     for (int k = 0; k < mat1.cols(); k++) {
       int rows_left = mat1.rows() - k;
       double beta, tau;
       mat1.col(k).segment(k, rows_left).makeHouseholder(tempV2, tau, beta);
       mat1.block(k, k, rows_left, mat1.cols() - k).applyHouseholderOnTheLeft(tempV2, tau, tempV1.data());
     }
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(double): HOUSEHOLDER QR CUSTOM", times_ms);
 
@@ -255,11 +254,11 @@ int main(int argc, char **argv) {
   // EIGEN3(float): RANDOM BIG MATRIX
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXf mat1 = Eigen::MatrixXf::Random(big_matrix_eigen1, big_matrix_eigen1);
     Eigen::MatrixXf mat2 = Eigen::MatrixXf::Random(big_matrix_eigen1, big_matrix_eigen1);
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(float): RANDOM BIG MATRIX", times_ms);
 
@@ -268,10 +267,10 @@ int main(int argc, char **argv) {
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXf mat1 = Eigen::MatrixXf::Random(big_matrix_eigen1, big_matrix_eigen1);
     Eigen::MatrixXf mat2 = Eigen::MatrixXf::Random(big_matrix_eigen1, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXf mat3 = mat1 * mat2;
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(float): MATRIX MULTIPLY", times_ms);
 
@@ -279,10 +278,10 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXf mat1 = Eigen::MatrixXf::Random(big_matrix_eigen1, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     mat1 = mat1.inverse();
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(float): MATRIX INVERSION", times_ms);
 
@@ -290,11 +289,11 @@ int main(int argc, char **argv) {
   times_ms.clear();
   Eigen::MatrixXf mat1 = Eigen::MatrixXf::Random(big_matrix_eigen2, big_matrix_eigen1);
   for (int i = 0; i < num_trials; i++) {
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXf Q = mat1.householderQr().householderQ();
     Eigen::MatrixXf R = Q.transpose() * mat1;
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(float): HOUSEHOLDER QR FULL", times_ms);
 
@@ -302,10 +301,10 @@ int main(int argc, char **argv) {
   times_ms.clear();
   for (int i = 0; i < num_trials; i++) {
     Eigen::MatrixXf mat1 = Eigen::MatrixXf::Random(big_matrix_eigen2, big_matrix_eigen1);
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     Eigen::MatrixXf R = mat1.colPivHouseholderQr().matrixR().triangularView<Eigen::Upper>();
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(float): HOUSEHOLDER QR PIV", times_ms);
 
@@ -315,15 +314,15 @@ int main(int argc, char **argv) {
     Eigen::MatrixXf mat1 = Eigen::MatrixXf::Random(big_matrix_eigen2, big_matrix_eigen1);
     Eigen::VectorXf tempV1 = Eigen::VectorXf::Zero(big_matrix_eigen2 * big_matrix_eigen1, 1);
     Eigen::VectorXf tempV2;
-    auto rT1 = boost::posix_time::microsec_clock::local_time();
+    auto rT1 = std::chrono::steady_clock::now();
     for (int k = 0; k < mat1.cols(); k++) {
       int rows_left = mat1.rows() - k;
       float beta, tau;
       mat1.col(k).segment(k, rows_left).makeHouseholder(tempV2, tau, beta);
       mat1.block(k, k, rows_left, mat1.cols() - k).applyHouseholderOnTheLeft(tempV2, tau, tempV1.data());
     }
-    auto rT2 = boost::posix_time::microsec_clock::local_time();
-    times_ms.push_back((rT2 - rT1).total_microseconds() * 1e-3);
+    auto rT2 = std::chrono::steady_clock::now();
+    times_ms.push_back(std::chrono::duration<double, std::milli>(rT2 - rT1).count());
   }
   print_stats("EIGEN3(float): HOUSEHOLDER QR CUSTOM", times_ms);
 

--- a/thirdparty/open_vins/ov_core/src/test_webcam.cpp
+++ b/thirdparty/open_vins/ov_core/src/test_webcam.cpp
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
 #include <cmath>
 #include <csignal>
 #include <deque>
@@ -30,9 +31,6 @@
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
-
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem.hpp>
 
 #include "cam/CamRadtan.h"
 #include "feat/Feature.h"

--- a/thirdparty/open_vins/ov_core/src/track/TrackAruco.cpp
+++ b/thirdparty/open_vins/ov_core/src/track/TrackAruco.cpp
@@ -19,6 +19,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
+
 #include "TrackAruco.h"
 
 #include "cam/CamBase.h"
@@ -59,7 +61,7 @@ void TrackAruco::feed_new_camera(const CameraData &message) {
 void TrackAruco::perform_tracking(double timestamp, const cv::Mat &imgin, size_t cam_id, const cv::Mat &maskin) {
 
   // Start timing
-  rT1 = boost::posix_time::microsec_clock::local_time();
+  rT1 = std::chrono::steady_clock::now();
 
   // Lock this data feed for this camera
   std::lock_guard<std::mutex> lck(mtx_feeds.at(cam_id));
@@ -95,7 +97,7 @@ void TrackAruco::perform_tracking(double timestamp, const cv::Mat &imgin, size_t
 
   // Perform extraction
   cv::aruco::detectMarkers(img0, aruco_dict, corners[cam_id], ids_aruco[cam_id], aruco_params, rejects[cam_id]);
-  rT2 = boost::posix_time::microsec_clock::local_time();
+  rT2 = std::chrono::steady_clock::now();
 
   //===================================================================================
   //===================================================================================
@@ -158,13 +160,13 @@ void TrackAruco::perform_tracking(double timestamp, const cv::Mat &imgin, size_t
     ids_last[cam_id] = ids_new;
     pts_last[cam_id] = pts_new;
   }
-  rT3 = boost::posix_time::microsec_clock::local_time();
+  rT3 = std::chrono::steady_clock::now();
 
   // Timing information
-  PRINT_ALL("[TIME-ARUCO]: %.4f seconds for detection\n", (rT2 - rT1).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-ARUCO]: %.4f seconds for feature DB update (%d features)\n", (rT3 - rT2).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-ARUCO]: %.4f seconds for detection\n", std::chrono::duration<double>(rT2 - rT1).count());
+  PRINT_ALL("[TIME-ARUCO]: %.4f seconds for feature DB update (%d features)\n", std::chrono::duration<double>(rT3 - rT2).count(),
             (int)ids_new.size());
-  PRINT_ALL("[TIME-ARUCO]: %.4f seconds for total\n", (rT3 - rT1).total_microseconds() * 1e-6);
+  PRINT_ALL("[TIME-ARUCO]: %.4f seconds for total\n", std::chrono::duration<double>(rT3 - rT1).count());
 }
 
 void TrackAruco::display_active(cv::Mat &img_out, int r1, int g1, int b1, int r2, int g2, int b2, std::string overlay) {

--- a/thirdparty/open_vins/ov_core/src/track/TrackBase.h
+++ b/thirdparty/open_vins/ov_core/src/track/TrackBase.h
@@ -23,12 +23,12 @@
 #define OV_CORE_TRACK_BASE_H
 
 #include <atomic>
+#include <chrono>
 #include <iostream>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/opencv.hpp>
@@ -192,7 +192,7 @@ protected:
   std::atomic<size_t> currid;
 
   // Timing variables (most children use these...)
-  boost::posix_time::ptime rT1, rT2, rT3, rT4, rT5, rT6, rT7;
+  std::chrono::steady_clock::time_point rT1, rT2, rT3, rT4, rT5, rT6, rT7;
 };
 
 } // namespace ov_core

--- a/thirdparty/open_vins/ov_core/src/track/TrackDescriptor.cpp
+++ b/thirdparty/open_vins/ov_core/src/track/TrackDescriptor.cpp
@@ -19,6 +19,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
+
 #include "TrackDescriptor.h"
 
 #include <opencv2/features2d.hpp>
@@ -63,7 +65,7 @@ void TrackDescriptor::feed_new_camera(const CameraData &message) {
 void TrackDescriptor::feed_monocular(const CameraData &message, size_t msg_id) {
 
   // Start timing
-  rT1 = boost::posix_time::microsec_clock::local_time();
+  rT1 = std::chrono::steady_clock::now();
 
   // Lock this data feed for this camera
   size_t cam_id = message.sensor_ids.at(msg_id);
@@ -105,14 +107,14 @@ void TrackDescriptor::feed_monocular(const CameraData &message, size_t msg_id) {
 
   // First, extract new descriptors for this new image
   perform_detection_monocular(img, mask, pts_new, desc_new, ids_new);
-  rT2 = boost::posix_time::microsec_clock::local_time();
+  rT2 = std::chrono::steady_clock::now();
 
   // Our matches temporally
   std::vector<cv::DMatch> matches_ll;
 
   // Lets match temporally
   robust_match(pts_last[cam_id], pts_new, desc_last[cam_id], desc_new, cam_id, cam_id, matches_ll);
-  rT3 = boost::posix_time::microsec_clock::local_time();
+  rT3 = std::chrono::steady_clock::now();
 
   // Get our "good tracks"
   std::vector<cv::KeyPoint> good_left;
@@ -146,7 +148,7 @@ void TrackDescriptor::feed_monocular(const CameraData &message, size_t msg_id) {
       good_ids_left.push_back(ids_new[i]);
     }
   }
-  rT4 = boost::posix_time::microsec_clock::local_time();
+  rT4 = std::chrono::steady_clock::now();
 
   // Update our feature database, with theses new observations
   for (size_t i = 0; i < good_left.size(); i++) {
@@ -166,21 +168,21 @@ void TrackDescriptor::feed_monocular(const CameraData &message, size_t msg_id) {
     ids_last[cam_id] = good_ids_left;
     desc_last[cam_id] = good_desc_left;
   }
-  rT5 = boost::posix_time::microsec_clock::local_time();
+  rT5 = std::chrono::steady_clock::now();
 
   // Our timing information
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for detection\n", (rT2 - rT1).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for matching\n", (rT3 - rT2).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for merging\n", (rT4 - rT3).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for feature DB update (%d features)\n", (rT5 - rT4).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for detection\n", std::chrono::duration<double>(rT2 - rT1).count());
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for matching\n", std::chrono::duration<double>(rT3 - rT2).count());
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for merging\n", std::chrono::duration<double>(rT4 - rT3).count());
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for feature DB update (%d features)\n", std::chrono::duration<double>(rT5 - rT4).count(),
             (int)good_left.size());
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for total\n", (rT5 - rT1).total_microseconds() * 1e-6);
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for total\n", std::chrono::duration<double>(rT5 - rT1).count());
 }
 
 void TrackDescriptor::feed_stereo(const CameraData &message, size_t msg_id_left, size_t msg_id_right) {
 
   // Start timing
-  rT1 = boost::posix_time::microsec_clock::local_time();
+  rT1 = std::chrono::steady_clock::now();
 
   // Lock this data feed for this camera
   size_t cam_id_left = message.sensor_ids.at(msg_id_left);
@@ -235,7 +237,7 @@ void TrackDescriptor::feed_stereo(const CameraData &message, size_t msg_id_left,
   // First, extract new descriptors for this new image
   perform_detection_stereo(img_left, img_right, mask_left, mask_right, pts_left_new, pts_right_new, desc_left_new, desc_right_new,
                            cam_id_left, cam_id_right, ids_left_new, ids_right_new);
-  rT2 = boost::posix_time::microsec_clock::local_time();
+  rT2 = std::chrono::steady_clock::now();
 
   // Our matches temporally
   std::vector<cv::DMatch> matches_ll, matches_rr;
@@ -248,7 +250,7 @@ void TrackDescriptor::feed_stereo(const CameraData &message, size_t msg_id_left,
                                  is_left ? matches_ll : matches_rr);
                   }
                 }));
-  rT3 = boost::posix_time::microsec_clock::local_time();
+  rT3 = std::chrono::steady_clock::now();
 
   // Get our "good tracks"
   std::vector<cv::KeyPoint> good_left, good_right;
@@ -304,7 +306,7 @@ void TrackDescriptor::feed_stereo(const CameraData &message, size_t msg_id_left,
       good_ids_right.push_back(ids_left_new[i]);
     }
   }
-  rT4 = boost::posix_time::microsec_clock::local_time();
+  rT4 = std::chrono::steady_clock::now();
 
   //===================================================================================
   //===================================================================================
@@ -341,15 +343,15 @@ void TrackDescriptor::feed_stereo(const CameraData &message, size_t msg_id_left,
     desc_last[cam_id_left] = good_desc_left;
     desc_last[cam_id_right] = good_desc_right;
   }
-  rT5 = boost::posix_time::microsec_clock::local_time();
+  rT5 = std::chrono::steady_clock::now();
 
   // Our timing information
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for detection\n", (rT2 - rT1).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for matching\n", (rT3 - rT2).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for merging\n", (rT4 - rT3).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for feature DB update (%d features)\n", (rT5 - rT4).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for detection\n", std::chrono::duration<double>(rT2 - rT1).count());
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for matching\n", std::chrono::duration<double>(rT3 - rT2).count());
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for merging\n", std::chrono::duration<double>(rT4 - rT3).count());
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for feature DB update (%d features)\n", std::chrono::duration<double>(rT5 - rT4).count(),
             (int)good_left.size());
-  PRINT_ALL("[TIME-DESC]: %.4f seconds for total\n", (rT5 - rT1).total_microseconds() * 1e-6);
+  PRINT_ALL("[TIME-DESC]: %.4f seconds for total\n", std::chrono::duration<double>(rT5 - rT1).count());
 }
 
 void TrackDescriptor::perform_detection_monocular(const cv::Mat &img0, const cv::Mat &mask0, std::vector<cv::KeyPoint> &pts0,

--- a/thirdparty/open_vins/ov_core/src/track/TrackDescriptor.h
+++ b/thirdparty/open_vins/ov_core/src/track/TrackDescriptor.h
@@ -143,7 +143,7 @@ protected:
                             std::vector<cv::DMatch> &good_matches);
 
   // Timing variables
-  boost::posix_time::ptime rT1, rT2, rT3, rT4, rT5, rT6, rT7;
+  std::chrono::steady_clock::time_point rT1, rT2, rT3, rT4, rT5, rT6, rT7;
 
   // Our orb extractor
   cv::Ptr<cv::ORB> orb0 = cv::ORB::create();

--- a/thirdparty/open_vins/ov_core/src/track/TrackKLT.cpp
+++ b/thirdparty/open_vins/ov_core/src/track/TrackKLT.cpp
@@ -19,6 +19,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
+
 #include "TrackKLT.h"
 
 #include "Grider_FAST.h"
@@ -45,7 +47,7 @@ void TrackKLT::feed_new_camera(const CameraData &message) {
   // Preprocessing steps that we do not parallelize
   // NOTE: DO NOT PARALLELIZE THESE!
   // NOTE: These seem to be much slower if you parallelize them...
-  rT1 = boost::posix_time::microsec_clock::local_time();
+  rT1 = std::chrono::steady_clock::now();
   size_t num_images = message.images.size();
   for (size_t msg_id = 0; msg_id < num_images; msg_id++) {
 
@@ -103,7 +105,7 @@ void TrackKLT::feed_monocular(const CameraData &message, size_t msg_id) {
   cv::Mat img = img_curr.at(cam_id);
   std::vector<cv::Mat> imgpyr = img_pyramid_curr.at(cam_id);
   cv::Mat mask = message.masks.at(msg_id);
-  rT2 = boost::posix_time::microsec_clock::local_time();
+  rT2 = std::chrono::steady_clock::now();
 
   // If we didn't have any successful tracks last time, just extract this time
   // This also handles, the tracking initalization on the first call to this extractor
@@ -128,7 +130,7 @@ void TrackKLT::feed_monocular(const CameraData &message, size_t msg_id) {
   auto pts_left_old = pts_last[cam_id];
   auto ids_left_old = ids_last[cam_id];
   perform_detection_monocular(img_pyramid_last[cam_id], img_mask_last[cam_id], pts_left_old, ids_left_old);
-  rT3 = boost::posix_time::microsec_clock::local_time();
+  rT3 = std::chrono::steady_clock::now();
 
   // Our return success masks, and predicted new features
   std::vector<uchar> mask_ll;
@@ -137,7 +139,7 @@ void TrackKLT::feed_monocular(const CameraData &message, size_t msg_id) {
   // Lets track temporally
   perform_matching(img_pyramid_last[cam_id], imgpyr, pts_left_old, pts_left_new, cam_id, cam_id, mask_ll);
   assert(pts_left_new.size() == ids_left_old.size());
-  rT4 = boost::posix_time::microsec_clock::local_time();
+  rT4 = std::chrono::steady_clock::now();
 
   // If any of our mask is empty, that means we didn't have enough to do ransac, so just return
   if (mask_ll.empty()) {
@@ -187,16 +189,16 @@ void TrackKLT::feed_monocular(const CameraData &message, size_t msg_id) {
     pts_last[cam_id] = good_left;
     ids_last[cam_id] = good_ids_left;
   }
-  rT5 = boost::posix_time::microsec_clock::local_time();
+  rT5 = std::chrono::steady_clock::now();
 
   // Timing information
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for pyramid\n", (rT2 - rT1).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for detection (%zu detected)\n", (rT3 - rT2).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for pyramid\n", std::chrono::duration<double>(rT2 - rT1).count());
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for detection (%zu detected)\n", std::chrono::duration<double>(rT3 - rT2).count(),
             (int)pts_last[cam_id].size() - pts_before_detect);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for temporal klt\n", (rT4 - rT3).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for feature DB update (%d features)\n", (rT5 - rT4).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for temporal klt\n", std::chrono::duration<double>(rT4 - rT3).count());
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for feature DB update (%d features)\n", std::chrono::duration<double>(rT5 - rT4).count(),
             (int)good_left.size());
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for total\n", (rT5 - rT1).total_microseconds() * 1e-6);
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for total\n", std::chrono::duration<double>(rT5 - rT1).count());
 }
 
 void TrackKLT::feed_stereo(const CameraData &message, size_t msg_id_left, size_t msg_id_right) {
@@ -214,7 +216,7 @@ void TrackKLT::feed_stereo(const CameraData &message, size_t msg_id_left, size_t
   std::vector<cv::Mat> imgpyr_right = img_pyramid_curr.at(cam_id_right);
   cv::Mat mask_left = message.masks.at(msg_id_left);
   cv::Mat mask_right = message.masks.at(msg_id_right);
-  rT2 = boost::posix_time::microsec_clock::local_time();
+  rT2 = std::chrono::steady_clock::now();
 
   // If we didn't have any successful tracks last time, just extract this time
   // This also handles, the tracking initalization on the first call to this extractor
@@ -249,7 +251,7 @@ void TrackKLT::feed_stereo(const CameraData &message, size_t msg_id_left, size_t
   perform_detection_stereo(img_pyramid_last[cam_id_left], img_pyramid_last[cam_id_right], img_mask_last[cam_id_left],
                            img_mask_last[cam_id_right], cam_id_left, cam_id_right, pts_left_old, pts_right_old, ids_left_old,
                            ids_right_old);
-  rT3 = boost::posix_time::microsec_clock::local_time();
+  rT3 = std::chrono::steady_clock::now();
 
   // Our return success masks, and predicted new features
   std::vector<uchar> mask_ll, mask_rr;
@@ -266,7 +268,7 @@ void TrackKLT::feed_stereo(const CameraData &message, size_t msg_id_left, size_t
                                      is_left ? mask_ll : mask_rr);
                   }
                 }));
-  rT4 = boost::posix_time::microsec_clock::local_time();
+  rT4 = std::chrono::steady_clock::now();
 
   //===================================================================================
   //===================================================================================
@@ -276,7 +278,7 @@ void TrackKLT::feed_stereo(const CameraData &message, size_t msg_id_left, size_t
   // TODO: maybe we should collect all tracks that are in both frames and make they pass this?
   // std::vector<uchar> mask_lr;
   // perform_matching(imgpyr_left, imgpyr_right, pts_left_new, pts_right_new, cam_id_left, cam_id_right, mask_lr);
-  rT5 = boost::posix_time::microsec_clock::local_time();
+  rT5 = std::chrono::steady_clock::now();
 
   //===================================================================================
   //===================================================================================
@@ -379,17 +381,17 @@ void TrackKLT::feed_stereo(const CameraData &message, size_t msg_id_left, size_t
     ids_last[cam_id_left] = good_ids_left;
     ids_last[cam_id_right] = good_ids_right;
   }
-  rT6 = boost::posix_time::microsec_clock::local_time();
+  rT6 = std::chrono::steady_clock::now();
 
   //  // Timing information
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for pyramid\n", (rT2 - rT1).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for detection (%d detected)\n", (rT3 - rT2).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for pyramid\n", std::chrono::duration<double>(rT2 - rT1).count());
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for detection (%d detected)\n", std::chrono::duration<double>(rT3 - rT2).count(),
             (int)pts_last[cam_id_left].size() - pts_before_detect);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for temporal klt\n", (rT4 - rT3).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for stereo klt\n", (rT5 - rT4).total_microseconds() * 1e-6);
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for feature DB update (%d features)\n", (rT6 - rT5).total_microseconds() * 1e-6,
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for temporal klt\n", std::chrono::duration<double>(rT4 - rT3).count());
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for stereo klt\n", std::chrono::duration<double>(rT5 - rT4).count());
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for feature DB update (%d features)\n", std::chrono::duration<double>(rT6 - rT5).count(),
             (int)good_left.size());
-  PRINT_ALL("[TIME-KLT]: %.4f seconds for total\n", (rT6 - rT1).total_microseconds() * 1e-6);
+  PRINT_ALL("[TIME-KLT]: %.4f seconds for total\n", std::chrono::duration<double>(rT6 - rT1).count());
 }
 
 void TrackKLT::perform_detection_monocular(const std::vector<cv::Mat> &img0pyr, const cv::Mat &mask0, std::vector<cv::KeyPoint> &pts0,

--- a/thirdparty/open_vins/ov_core/src/utils/opencv_yaml_parse.h
+++ b/thirdparty/open_vins/ov_core/src/utils/opencv_yaml_parse.h
@@ -23,7 +23,7 @@
 #define OPENCV_YAML_PARSER_H
 
 #include <Eigen/Eigen>
-#include <boost/filesystem.hpp>
+#include <fstream>
 #include <memory>
 #include <opencv2/opencv.hpp>
 
@@ -55,6 +55,13 @@ namespace ov_core {
  * NOTE: The camera and imu have nested, but those are handled externally.
  * They first read the "imu0" or "cam1" level, after-which all values are at the same level.
  */
+/// Check a file is readable. This is the only filesystem operation ov_core needs, so we
+/// avoid pulling in <filesystem> and the c++17 requirement that would come with it.
+inline bool file_exists(const std::string &path) {
+  std::ifstream f(path);
+  return f.good();
+}
+
 class YamlParser {
 public:
   /**
@@ -65,11 +72,11 @@ public:
   explicit YamlParser(const std::string &config_path, bool fail_if_not_found = true) : config_path_(config_path) {
 
     // Check if file exists
-    if (!fail_if_not_found && !boost::filesystem::exists(config_path)) {
+    if (!fail_if_not_found && !file_exists(config_path)) {
       config = nullptr;
       return;
     }
-    if (!boost::filesystem::exists(config_path)) {
+    if (!file_exists(config_path)) {
       PRINT_ERROR(RED "unable to open the configuration file!\n%s\n" RESET, config_path.c_str());
       std::exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Removes Boost from `mins`, `mins_eval` and the vendored `ov_core`. **Stacked on #66** -- review/merge that first, this branches off it.

### Why this needed all three packages

De-Boosting only `mins` would not have achieved anything: `ov_core` hard-depends on Boost and MINS includes its headers (`opencv_yaml_parse.h` pulled `<boost/filesystem.hpp>`, `TrackBase.h` pulled `<boost/date_time>` and declared `boost::posix_time::ptime rT1..rT7` as members). So Boost would have stayed mandatory for the no-ROS/mac build regardless. `thirdparty/open_vins` is vendored (not a submodule), so it is de-Boosted here too -- that does diverge us from upstream `rpng/open_vins`, which is the main thing to push back on if you would rather send it upstream first.

### The c++17 bump

`std::filesystem` needs c++17, so `mins` and `mins_eval` move from 14 to 17. Melodic's stock GCC 7.5 has the c++17 *language* but ships filesystem only under `<experimental/>`, so there is a small `fs_compat.h` (`__has_include` switch) plus a conditional `stdc++fs` link for GCC < 9.1. `ov_core` needed only `exists()` on the config file, so it gets a 3-line `ifstream` check and **stays at c++14** -- no shim, no bump there.

### What changed

| was | now |
| --- | --- |
| `boost::filesystem` (9 files in mins, 2 in mins_eval) | `std::filesystem` via `fs_compat.h` |
| `boost::posix_time` (TimeChecker + 41 timer sites in ov_core) | `std::chrono::steady_clock` |
| `boost::math::chi_squared` quantile (3 sites) | `mins/src/utils/chi_square.h` |
| `boost::algorithm::replace_all_copy` | 5-line helper in run_comparison.cpp |
| `std::random_shuffle` | `std::shuffle` + `mt19937` |

Two things worth flagging:

**`random_shuffle` was a latent mac blocker.** `MathGPS.h` called it (unqualified, via `using namespace std`). C++17 *removed* it -- libstdc++ still ships it as a deprecated extension so every Linux job stays green, but libc++ deletes it and Apple Clang hard-errors. It would have failed only once we tried a mac build, with CI green the whole way. Now `std::shuffle` with an explicit `mt19937(1337)` replacing `srand(1337)`. **This changes the random sequence**, so `get_random_subset` picks a different subset and the GPS runs may show a small ATE delta -- expected rebaseline, not a regression.

**The chi-square replacement is exact, not an approximation.** I avoided Wilson-Hilferty (~1% off, would have moved the chi2 gate). It's a safeguarded Newton iteration on the regularized incomplete gamma. Checked against `boost::math` over the full range `UpdaterStatistics` builds: **worst relative error 9.0e-14 across dof 1..999 at p=0.95**, and 1.0e-13 over p in {0.5 .. 0.999}. Thresholds are identical to ~13 significant digits, so the gate should not move.

### Verified locally (not just CI)

All four CI configs built from this tree in docker:

- **Melodic 18.04 / GCC 7.5** -- all 6 packages. This is the one that exercises the `<experimental/filesystem>` + `stdc++fs` path.
- **Noetic 20.04 / GCC 9.4** -- all 4 packages (`catkin build mins mins_eval`).
- **Humble 22.04 / ROS2** -- all 5 packages incl. `mins_eval`.
- **No-ROS 22.04** -- `mins_cli` builds with `libboost-all-dev` dropped from the Dockerfile, and `ldd` shows `mins_cli`, `libmins_lib.so` and `libov_core_lib.so` link **zero** Boost libraries.

### Boost is still installed, just not by us

Being precise about the win: `libpcl-visualization` / `libpcl-recognition` depend on `libboost-filesystem`, so Boost still lands in the image (and `brew install pcl` will still pull it on mac). What changed is that MINS no longer *uses* or *links* it -- it's PCL's dependency now, not ours.

`ROSSubscriber.cpp` keeps its 4 `boost::bind` calls: `message_filters::Signal9` invokes the callback with 9 args and only a bind expression tolerates that (a fixed-arity lambda does not compile). It's ROS1-only, where roscpp mandates Boost anyway (`ImageConstPtr` *is* a `boost::shared_ptr`), so converting it would be churn for no dependency win.