### PR TITLE
fix eval scoring wheel configs against the holonomic ground truth

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -62,16 +62,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # gt: which GroundTruths set the run must be scored against.
+          # Wheel configs: MINS forces a non-holonomic sim trajectory whenever wheel is
+          # enabled (see Options.cpp), and the wheel odometry model is planar, so those
+          # runs need sim_const_planar:=true and the nonholonomic_planar ground truth.
+          # Scoring them against holonomic compares two different trajectories and yields
+          # a meaningless ~134 deg orientation RMSE.
           - config: vio_stereo
+            gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=false vicon_enabled:=false"
           - config: stereo_lidar
+            gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=true gps_enabled:=false wheel_enabled:=false vicon_enabled:=false"
           - config: stereo_gps
+            gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=true wheel_enabled:=false vicon_enabled:=false"
           - config: stereo_wheel
-            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=true vicon_enabled:=false"
+            gt: nonholonomic_planar
+            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=true vicon_enabled:=false sim_const_planar:=true"
           - config: full
-            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=true gps_enabled:=true wheel_enabled:=true vicon_enabled:=false"
+            gt: nonholonomic_planar
+            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=true gps_enabled:=true wheel_enabled:=true vicon_enabled:=false sim_const_planar:=true"
     steps:
       - name: Checkout (for report script)
         uses: actions/checkout@v4
@@ -116,7 +127,7 @@ jobs:
             source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash
             roslaunch mins_eval comparison.launch viz_type:=0 align_mode:=se3 \
               path_alg:=/alg \
-              path_gts:=/catkin_ws/src/MINS/mins_data/GroundTruths/holonomic' \
+              path_gts:=/catkin_ws/src/MINS/mins_data/GroundTruths/${{ matrix.gt }}' \
             2>/dev/null | tee "comparison_${{ matrix.config }}.txt"
       - name: Parse to markdown
         run: |


### PR DESCRIPTION
The wheel configs (`stereo_wheel`, `full`) were being scored against the **holonomic** ground truth, which is a different trajectory. That is where the ~134 deg orientation RMSE and ~2e6 NEES in every eval report came from -- those numbers were never real.

It hid well because the value was identical on the master and PR sides, so the delta was always `+0.0%` and nothing looked broken.

### Root cause

`mins/src/options/Options.cpp:45` force-disables the holonomic constraint whenever wheel is enabled:

```cpp
// force nonholonomic constraint to simulated trajectory when using wheel measurements
if (est->wheel->enabled && sim->const_holonomic && fs::exists(...)) {
  PRINT3(YELLOW "Enable non-holonomic constraint for wheel simulation.\n" RESET);
  sim->const_holonomic = false;
}
```

So the sim silently generates a non-holonomic trajectory, while `path_gts` was hardcoded to `GroundTruths/holonomic` for all five configs. `UD_Warehouse.txt` exists in all three GT sets, so the eval happily found a file and compared against the wrong one. The ROS param even still prints `sim_const_holonomic: True` -- the override happens after parsing, so you cannot tell from the launch args.

Position stayed plausible (~0.1 m) because the path is similar; only attitude diverges, which is why orientation alone looked insane.

### Fix

Per-config `gt:` in the matrix. Wheel configs also need `sim_const_planar:=true` -- a wheeled ground robot is non-holonomic **and** planar, and the wheel odometry model assumes planar motion. MINS forces the holonomic flag automatically but not the planar one.

### Measured locally (seed 0, `stereo_wheel`)

| GT | orientation | position |
| --- | --- | --- |
| holonomic (before) | 133.85 deg | 0.111 m |
| nonholonomic | 74.84 deg | 14.35 m |
| nonholonomic_planar, `const_planar=false` | 1.51 deg | 0.154 m |
| **nonholonomic_planar + `const_planar:=true` (this PR)** | **0.198 deg** | **0.092 m** |

For reference `vio_stereo` vs holonomic is **0.178 deg / 0.127 m**, so the wheel configs now land in the same place as the other configs instead of 700x off. Confirmed the same on `full` (0.20 deg) and across seeds.

### Also worth knowing

`GroundTruths/nonholonomic` appears **stale**: its time base is 2.61-51.52 s versus 1.20-50.00 s for the other two, and it matches no config (~14 m off for both a holonomic and a non-holonomic run). Nothing in CI referenced it before or after this PR. Might be worth regenerating or removing it, but I left it alone here.

Only touches `.github/workflows/evaluation.yml`. The eval job is informational and does not block merge, so the next PR's report should just start showing real wheel numbers.