### PR TITLE
add macOS CI job for the ROS-free CLI

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,0 +1,63 @@
+name: macOS Workflow
+
+# Builds the MINS core library + headless CLI natively on macOS (Apple Silicon, Apple Clang,
+# libc++). No ROS, and no Docker -- macOS runners cannot run the Linux images, so this is the
+# only job proving MINS builds outside the GNU/Linux toolchain. It also uploads mins_cli, so
+# every build produces a downloadable macOS binary.
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_macos:
+    name: "No ROS - macOS (arm64)"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          # Boost is deliberately absent: MINS does not use it. PCL still pulls it in itself.
+          brew install eigen opencv pcl yaml-cpp
+          echo "--- toolchain ---"
+          clang++ --version | head -2
+          cmake --version | head -1
+
+      - name: Configure
+        run: |
+          cmake -S mins -B build/mins \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_ROS=OFF \
+            -DENABLE_ARUCO_TAGS=OFF \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+
+      - name: Build
+        run: cmake --build build/mins -j"$(sysctl -n hw.ncpu)"
+
+      - name: Inspect binary
+        run: |
+          file build/mins/mins_cli
+          otool -L build/mins/mins_cli
+
+      - name: Run headless CLI end to end
+        run: |
+          set -eo pipefail
+          export MINS_ROOT="$PWD"
+          # config_system.yaml writes to MINS_DIR/../../../../outputs, i.e. four levels above
+          # $MINS_ROOT/mins -- outside the checkout. Create it up front like the Linux job does.
+          mkdir -p "$PWD/../../../outputs/tmp/0"
+          ./build/mins/mins_cli mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log
+          grep -q "RMSE average" /tmp/cli.log
+
+      - name: Upload macOS binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: mins_cli-macos-arm64
+          path: build/mins/mins_cli
+          retention-days: 14

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -23,19 +23,29 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Boost is deliberately absent: MINS does not use it. PCL still pulls it in itself.
-          brew install eigen opencv pcl yaml-cpp
+          # Pinned on purpose. Homebrew's default eigen/opencv are now 5.x, and MINS supports
+          # neither (CMakeLists asks for OpenCV 4 or 3, and the code is Eigen 3 API), so we use
+          # the versioned formulae. Both are keg-only, hence the explicit *_DIR below.
+          # Boost is not requested: MINS does not use it. PCL depends on it, so brew installs
+          # it anyway -- mins_cli itself links none of it (see the otool output).
+          brew install eigen@3 opencv@4 pcl yaml-cpp
           echo "--- toolchain ---"
           clang++ --version | head -2
           cmake --version | head -1
+          echo "eigen@3:  $(brew --prefix eigen@3)"
+          echo "opencv@4: $(brew --prefix opencv@4)"
 
       - name: Configure
         run: |
+          # PCL pulls in the unversioned eigen (5.x) as its own dependency, so point Eigen3_DIR
+          # and the prefix path at eigen@3 explicitly rather than rely on include ordering.
           cmake -S mins -B build/mins \
             -DCMAKE_BUILD_TYPE=Release \
             -DENABLE_ROS=OFF \
             -DENABLE_ARUCO_TAGS=OFF \
-            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+            -DEigen3_DIR="$(brew --prefix eigen@3)/share/eigen3/cmake" \
+            -DOpenCV_DIR="$(brew --prefix opencv@4)/lib/cmake/opencv4" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix eigen@3);$(brew --prefix opencv@4);$(brew --prefix)"
 
       - name: Build
         run: cmake --build build/mins -j"$(sysctl -n hw.ncpu)"

--- a/mins/cmake/ROS1.cmake
+++ b/mins/cmake/ROS1.cmake
@@ -91,7 +91,9 @@ else ()
 
     # ov_core was pulled in above (before LIBRARY_SOURCES); just link + find PCL here.
     # (In a ROS build PCL comes via catkin/pcl_ros; standalone we link it ourselves.)
-    find_package(PCL REQUIRED)
+    # Only the components we actually use: point types + transforms (common) and VoxelGrid
+    # (filters). Asking for all of PCL drags in pcl_visualization -> VTK, which we never use.
+    find_package(PCL REQUIRED COMPONENTS common filters)
     include_directories(${PCL_INCLUDE_DIRS})
     link_directories(${PCL_LIBRARY_DIRS})
     add_definitions(${PCL_DEFINITIONS})

--- a/mins/cmake/ROS2.cmake
+++ b/mins/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/mins_data/CMakeLists.txt
+++ b/mins_data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Project name
 project(mins_data)

--- a/mins_eval/cmake/ROS1.cmake
+++ b/mins_eval/cmake/ROS1.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(catkin REQUIRED COMPONENTS roscpp rospy geometry_msgs nav_msgs sensor_msgs ov_core ov_eval)
 # Describe ROS project

--- a/mins_eval/cmake/ROS2.cmake
+++ b/mins_eval/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(ament_cmake REQUIRED)
 

--- a/thirdparty/open_vins/ov_core/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 project(ov_core)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)

--- a/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(catkin QUIET COMPONENTS roscpp rosbag sensor_msgs cv_bridge)

--- a/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ros dependencies
 find_package(ament_cmake REQUIRED)

--- a/thirdparty/open_vins/ov_eval/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_eval/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 project(ov_eval)
 
 # Include libraries

--- a/thirdparty/open_vins/ov_eval/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_eval/cmake/ROS1.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(catkin QUIET COMPONENTS roscpp rospy geometry_msgs nav_msgs sensor_msgs ov_core)

--- a/thirdparty/open_vins/ov_eval/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_eval/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Builds the ROS-free `mins_cli` natively on `macos-latest` (Apple Silicon, Apple Clang, libc++) and uploads the binary as an artifact.

> **Chained on #67** -- this branch is cut from `ros2/drop-boost`, so until #67 merges the diff below also shows its 41 files. It targets `master` on purpose so CI actually runs (a PR based on a non-master branch gets **zero** check-runs, which is how #67 sat untested). Once #67 merges this collapses to just the one new workflow file.

### Why it needs #67 first

Apple Clang uses **libc++**, and libc++ *removed* `std::random_shuffle` in C++17. `mins/src/update/gps/MathGPS.h` called it (unqualified, via `using namespace std`), so the mac build cannot compile without #67's `std::shuffle` fix. libstdc++ keeps `random_shuffle` as a deprecated extension, which is exactly why all four Linux jobs stayed green while the mac build was impossible. #67 also bumps to C++17, which brew's current PCL requires anyway.

### What the job does

- `brew install eigen opencv pcl yaml-cpp` -- **no boost**, since MINS no longer uses it after #67 (PCL still pulls it in as its own dependency, so it ends up installed regardless -- just not by us, and `mins_cli` links none of it).
- `cmake -DENABLE_ROS=OFF -DENABLE_ARUCO_TAGS=OFF`. Aruco is off because OpenCV 4.7+ changed the aruco API and brew ships newer; MINS never uses `TrackAruco` (zero references in `mins/src`), ov_core just compiles it.
- Runs the simulator end to end and greps for `RMSE average`, same smoke check as the Linux ROS-free job.
- `otool -L` on the binary so the dylib dependencies are visible in the log.
- Uploads `mins_cli-macos-arm64` (14 day retention).

No Docker: macOS runners cannot run the Linux images, so this is the only job proving MINS builds off the GNU/Linux toolchain.

### What I verified before pushing

I have no Mac, so I dry-ran the **exact command sequence** on Linux with clang first. That confirmed: builds clean (warnings only), `MINS_ROOT=$PWD` resolves configs, the smoke grep hits (`RMSE average: 0.447, 0.239 (deg,m)`), and the output path is right -- `config_system.yaml` writes to `MINS_DIR/../../../../outputs`, i.e. **four levels above `$MINS_ROOT/mins`, outside the checkout**, which is why the job pre-creates `$PWD/../../../outputs/tmp/0` rather than a path inside the repo.

Also checked: MINS uses **no OpenMP** (so no libomp needed), and `pthread.h`/`unistd.h` both exist on macOS. `-fsee` and `-Wmaybe-uninitialized` are GCC-only, but clang accepts the first silently and only warns on the second -- noise, not failures. I left the flags alone rather than widen the diff; happy to guard them by compiler if you want a quiet log.

**Still unproven until this actually runs:** Apple Clang specifics, brew's prefix/formula layout, and arm64. Expect a round-trip or two.

### On shipping a binary

The artifact links against brew's dylibs, so it runs on a machine that has `brew install eigen opencv pcl yaml-cpp`. A binary that runs on any Mac would need the dylibs bundled plus code signing + notarization (Apple Developer account) to get past Gatekeeper -- worth deciding separately, not in this PR.