### PR TITLE
recover wheel-eval fix and macos ci onto master

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,0 +1,63 @@
+name: macOS Workflow
+
+# Builds the MINS core library + headless CLI natively on macOS (Apple Silicon, Apple Clang,
+# libc++). No ROS, and no Docker -- macOS runners cannot run the Linux images, so this is the
+# only job proving MINS builds outside the GNU/Linux toolchain. It also uploads mins_cli, so
+# every build produces a downloadable macOS binary.
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_macos:
+    name: "No ROS - macOS (arm64)"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          # Boost is deliberately absent: MINS does not use it. PCL still pulls it in itself.
+          brew install eigen opencv pcl yaml-cpp
+          echo "--- toolchain ---"
+          clang++ --version | head -2
+          cmake --version | head -1
+
+      - name: Configure
+        run: |
+          cmake -S mins -B build/mins \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_ROS=OFF \
+            -DENABLE_ARUCO_TAGS=OFF \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+
+      - name: Build
+        run: cmake --build build/mins -j"$(sysctl -n hw.ncpu)"
+
+      - name: Inspect binary
+        run: |
+          file build/mins/mins_cli
+          otool -L build/mins/mins_cli
+
+      - name: Run headless CLI end to end
+        run: |
+          set -eo pipefail
+          export MINS_ROOT="$PWD"
+          # config_system.yaml writes to MINS_DIR/../../../../outputs, i.e. four levels above
+          # $MINS_ROOT/mins -- outside the checkout. Create it up front like the Linux job does.
+          mkdir -p "$PWD/../../../outputs/tmp/0"
+          ./build/mins/mins_cli mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log
+          grep -q "RMSE average" /tmp/cli.log
+
+      - name: Upload macOS binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: mins_cli-macos-arm64
+          path: build/mins/mins_cli
+          retention-days: 14

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -23,19 +23,29 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Boost is deliberately absent: MINS does not use it. PCL still pulls it in itself.
-          brew install eigen opencv pcl yaml-cpp
+          # Pinned on purpose. Homebrew's default eigen/opencv are now 5.x, and MINS supports
+          # neither (CMakeLists asks for OpenCV 4 or 3, and the code is Eigen 3 API), so we use
+          # the versioned formulae. Both are keg-only, hence the explicit *_DIR below.
+          # Boost is not requested: MINS does not use it. PCL depends on it, so brew installs
+          # it anyway -- mins_cli itself links none of it (see the otool output).
+          brew install eigen@3 opencv@4 pcl yaml-cpp
           echo "--- toolchain ---"
           clang++ --version | head -2
           cmake --version | head -1
+          echo "eigen@3:  $(brew --prefix eigen@3)"
+          echo "opencv@4: $(brew --prefix opencv@4)"
 
       - name: Configure
         run: |
+          # PCL pulls in the unversioned eigen (5.x) as its own dependency, so point Eigen3_DIR
+          # and the prefix path at eigen@3 explicitly rather than rely on include ordering.
           cmake -S mins -B build/mins \
             -DCMAKE_BUILD_TYPE=Release \
             -DENABLE_ROS=OFF \
             -DENABLE_ARUCO_TAGS=OFF \
-            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+            -DEigen3_DIR="$(brew --prefix eigen@3)/share/eigen3/cmake" \
+            -DOpenCV_DIR="$(brew --prefix opencv@4)/lib/cmake/opencv4" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix eigen@3);$(brew --prefix opencv@4);$(brew --prefix)"
 
       - name: Build
         run: cmake --build build/mins -j"$(sysctl -n hw.ncpu)"

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -62,16 +62,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # gt: which GroundTruths set the run must be scored against.
+          # Wheel configs: MINS forces a non-holonomic sim trajectory whenever wheel is
+          # enabled (see Options.cpp), and the wheel odometry model is planar, so those
+          # runs need sim_const_planar:=true and the nonholonomic_planar ground truth.
+          # Scoring them against holonomic compares two different trajectories and yields
+          # a meaningless ~134 deg orientation RMSE.
           - config: vio_stereo
+            gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=false vicon_enabled:=false"
           - config: stereo_lidar
+            gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=true gps_enabled:=false wheel_enabled:=false vicon_enabled:=false"
           - config: stereo_gps
+            gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=true wheel_enabled:=false vicon_enabled:=false"
           - config: stereo_wheel
-            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=true vicon_enabled:=false"
+            gt: nonholonomic_planar
+            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=true vicon_enabled:=false sim_const_planar:=true"
           - config: full
-            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=true gps_enabled:=true wheel_enabled:=true vicon_enabled:=false"
+            gt: nonholonomic_planar
+            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=true gps_enabled:=true wheel_enabled:=true vicon_enabled:=false sim_const_planar:=true"
     steps:
       - name: Checkout (for report script)
         uses: actions/checkout@v4
@@ -116,7 +127,7 @@ jobs:
             source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash
             roslaunch mins_eval comparison.launch viz_type:=0 align_mode:=se3 \
               path_alg:=/alg \
-              path_gts:=/catkin_ws/src/MINS/mins_data/GroundTruths/holonomic' \
+              path_gts:=/catkin_ws/src/MINS/mins_data/GroundTruths/${{ matrix.gt }}' \
             2>/dev/null | tee "comparison_${{ matrix.config }}.txt"
       - name: Parse to markdown
         run: |

--- a/mins/cmake/ROS1.cmake
+++ b/mins/cmake/ROS1.cmake
@@ -91,7 +91,9 @@ else ()
 
     # ov_core was pulled in above (before LIBRARY_SOURCES); just link + find PCL here.
     # (In a ROS build PCL comes via catkin/pcl_ros; standalone we link it ourselves.)
-    find_package(PCL REQUIRED)
+    # Only the components we actually use: point types + transforms (common) and VoxelGrid
+    # (filters). Asking for all of PCL drags in pcl_visualization -> VTK, which we never use.
+    find_package(PCL REQUIRED COMPONENTS common filters)
     include_directories(${PCL_INCLUDE_DIRS})
     link_directories(${PCL_LIBRARY_DIRS})
     add_definitions(${PCL_DEFINITIONS})

--- a/mins/cmake/ROS2.cmake
+++ b/mins/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/mins_data/CMakeLists.txt
+++ b/mins_data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Project name
 project(mins_data)

--- a/mins_eval/cmake/ROS1.cmake
+++ b/mins_eval/cmake/ROS1.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(catkin REQUIRED COMPONENTS roscpp rospy geometry_msgs nav_msgs sensor_msgs ov_core ov_eval)
 # Describe ROS project

--- a/mins_eval/cmake/ROS2.cmake
+++ b/mins_eval/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(ament_cmake REQUIRED)
 

--- a/thirdparty/open_vins/ov_core/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 project(ov_core)
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)

--- a/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(catkin QUIET COMPONENTS roscpp rosbag sensor_msgs cv_bridge)

--- a/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ros dependencies
 find_package(ament_cmake REQUIRED)

--- a/thirdparty/open_vins/ov_eval/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_eval/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 project(ov_eval)
 
 # Include libraries

--- a/thirdparty/open_vins/ov_eval/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_eval/cmake/ROS1.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(catkin QUIET COMPONENTS roscpp rospy geometry_msgs nav_msgs sensor_msgs ov_core)

--- a/thirdparty/open_vins/ov_eval/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_eval/cmake/ROS2.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Brings the wheel-eval GT fix (#68) and the macOS CI job + native arm64 mins_cli exe (#69) onto master. Those PRs merged into their parent branches instead of master (bases were never retargeted, and the branches were not deleted), so their content never landed. Since #67 is already in master, this diff is exactly #68 + #69.