### PR TITLE
native windows cli build + ikd_Tree pthread->std port

### DIFF
--- a/.github/vcpkg-triplets/x64-windows-rel.cmake
+++ b/.github/vcpkg-triplets/x64-windows-rel.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+# Release only: the default x64-windows triplet builds every package in BOTH debug and
+# release, roughly doubling the vcpkg time. We only ship release, so skip the debug halves.
+set(VCPKG_BUILD_TYPE release)

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,4 +1,4 @@
-name: macOS Workflow
+name: macOS (arm64)
 
 # Builds the MINS core library + headless CLI natively on macOS (Apple Silicon, Apple Clang,
 # libc++). No ROS, and no Docker -- macOS runners cannot run the Linux images, so this is the

--- a/.github/workflows/build_ros1_melodic.yml
+++ b/.github/workflows/build_ros1_melodic.yml
@@ -1,4 +1,4 @@
-name: ROS 1 Workflow
+name: ROS1 Melodic (Ubuntu 18.04)
 
 on:
   push:
@@ -18,20 +18,10 @@ jobs:
       - name: Run MINS simulation (smoke test)
         run: docker run --rm --entrypoint /bin/bash mins:melodic -c "source /opt/ros/melodic/setup.bash && source /catkin_ws/devel/setup.bash && export OMP_NUM_THREADS=1 && roslaunch mins simulation.launch sys_verbosity:=3"
 
-  build_2004:
-    name: "ROS1 Ubuntu 20.04"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build the Docker image (Noetic 20.04)
-        run: docker build . --file Dockerfile_noetic_20_04 --tag mins:noetic
-      - name: Run MINS simulation (smoke test)
-        run: docker run --rm --entrypoint /bin/bash mins:noetic -c "source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash && export OMP_NUM_THREADS=1 && roslaunch mins simulation.launch sys_verbosity:=3"
-
   # build_1604 ("ROS1 Ubuntu 16.04", Kinetic): PARKED - revisit later.
   # Ubuntu 16.04/Xenial ships Eigen 3.2, but MINS's modern PCL/Ceres usage needs
   # Eigen >= 3.3, so a clean 16.04 build is unlikely without dedicated dependency
   # work. To re-enable:
   #   1. Add Dockerfile_kinetic_16_04 (FROM osrf/ros:kinetic-perception, python-catkin-tools,
   #      Eigen upgraded to 3.3.7 from source), and
-  #   2. Add a build_1604 job here mirroring the two above.
+  #   2. Add a build_1604 job here mirroring the one above.

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -1,0 +1,19 @@
+name: ROS1 Noetic (Ubuntu 20.04)
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_2004:
+    name: "ROS1 Ubuntu 20.04"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Docker image (Noetic 20.04)
+        run: docker build . --file Dockerfile_noetic_20_04 --tag mins:noetic
+      - name: Run MINS simulation (smoke test)
+        run: docker run --rm --entrypoint /bin/bash mins:noetic -c "source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash && export OMP_NUM_THREADS=1 && roslaunch mins simulation.launch sys_verbosity:=3"

--- a/.github/workflows/build_ros2.yml
+++ b/.github/workflows/build_ros2.yml
@@ -1,4 +1,4 @@
-name: ROS 2 Workflow
+name: ROS2 Humble (Ubuntu 22.04)
 
 on:
   push:

--- a/.github/workflows/build_rosfree.yml
+++ b/.github/workflows/build_rosfree.yml
@@ -1,4 +1,4 @@
-name: ROS-free Workflow
+name: ROS-free (Ubuntu 22.04)
 
 on:
   push:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,9 +1,9 @@
 name: Windows Workflow
 
-# Builds the MINS core library + headless CLI natively on Windows (MSVC, x64) with deps from
-# vcpkg (eigen3 only) and a prebuilt OpenCV package. No ROS, no Docker -- this is the only job
-# proving MINS builds on the MSVC toolchain. It uploads mins_cli.exe, so every build produces
-# a downloadable Windows binary.
+# Builds the MINS core library + headless CLI natively on Windows (MSVC, x64). No ROS, no
+# Docker, no vcpkg -- PCL is gone and the remaining deps (Eigen, OpenCV) are grabbed directly
+# (header-only install / prebuilt package), so a from-source vcpkg build is no longer needed
+# for this job. Uploads mins_cli.exe, so every build produces a downloadable Windows binary.
 
 on:
   push:
@@ -21,35 +21,38 @@ jobs:
         with:
           submodules: recursive
 
-      # eigen3 is header-only via vcpkg -- fast even uncached, no need to compile or cache it.
-      - name: Install eigen3 (vcpkg)
+      # Eigen is header-only -- install the headers and generate Eigen3Config.cmake so
+      # find_package(Eigen3) succeeds. No compiler build needed.
+      - name: Install Eigen3
         shell: bash
         run: |
-          vcpkg install eigen3 \
-            --triplet x64-windows-rel --overlay-triplets=.github/vcpkg-triplets
+          curl -sSL -o eigen.zip https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip
+          cmake -E tar xf eigen.zip
+          cmake -S eigen-3.4.0 -B eigen-build -G "Visual Studio 17 2022" -A x64 \
+            -DCMAKE_INSTALL_PREFIX=C:/eigen
+          cmake --build eigen-build --target install --config Release
 
-      # vcpkg's opencv4 port compiles OpenCV from source (~30+ min, even with PCL gone).
-      # Use the official prebuilt Windows package instead -- a self-extracting archive with
-      # no compile step, done in well under a minute.
+      # vcpkg's opencv4 port compiles OpenCV from source (~30+ min, even with PCL gone -- and
+      # its toolchain file also wraps find_package globally, which fights a manually supplied
+      # OpenCVConfig.cmake). Skip vcpkg for OpenCV entirely: use the official prebuilt Windows
+      # package, a self-extracting archive with no compile step.
       - name: Install OpenCV (prebuilt)
         shell: bash
         run: |
           curl -sSL -o opencv.exe https://github.com/opencv/opencv/releases/download/4.10.0/opencv-4.10.0-windows.exe
           ./opencv.exe -oC:/ -y
-          echo "OPENCV_DIR=C:/opencv/build" >> "$GITHUB_ENV"
 
       - name: Configure
         shell: bash
         run: |
           cmake -S mins -B build/mins \
+            -G "Visual Studio 17 2022" -A x64 \
             -DCMAKE_BUILD_TYPE=Release \
             -DENABLE_ROS=OFF \
             -DENABLE_ARUCO_TAGS=OFF \
-            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-            -DVCPKG_TARGET_TRIPLET=x64-windows-rel \
-            -DVCPKG_OVERLAY_TRIPLETS=.github/vcpkg-triplets \
-            -DOpenCV_DIR="$OPENCV_DIR" \
-            -DCMAKE_PREFIX_PATH="$OPENCV_DIR"
+            -DEigen3_DIR="C:/eigen/share/eigen3/cmake" \
+            -DOpenCV_DIR="C:/opencv/build" \
+            -DCMAKE_PREFIX_PATH="C:/opencv/build"
 
       - name: Build
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,4 @@
-name: Windows Workflow
+name: Windows (x64)
 
 # Builds the MINS core library + headless CLI natively on Windows (MSVC, x64) with deps from
 # vcpkg. No ROS, no Docker -- this is the only job proving MINS builds on the MSVC toolchain.

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           submodules: recursive
 
+      # vcpkg builds PCL (+boost/flann) from source -- ~40 min. Cache its built package
+      # archives so only the first run pays that cost; later runs restore in seconds.
+      - name: Cache vcpkg archives
+        uses: actions/cache@v4
+        with:
+          path: ~/AppData/Local/vcpkg/archives
+          key: vcpkg-x64-windows-v1
+
       - name: Install dependencies (vcpkg)
         shell: bash
         run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,8 +1,9 @@
 name: Windows Workflow
 
 # Builds the MINS core library + headless CLI natively on Windows (MSVC, x64) with deps from
-# vcpkg. No ROS, no Docker -- this is the only job proving MINS builds on the MSVC toolchain.
-# It uploads mins_cli.exe, so every build produces a downloadable Windows binary.
+# vcpkg (eigen3 only) and a prebuilt OpenCV package. No ROS, no Docker -- this is the only job
+# proving MINS builds on the MSVC toolchain. It uploads mins_cli.exe, so every build produces
+# a downloadable Windows binary.
 
 on:
   push:
@@ -20,23 +21,22 @@ jobs:
         with:
           submodules: recursive
 
-      # vcpkg builds opencv from source (the heavy one now that PCL is gone). Cache the
-      # installed tree so only the first run pays that cost; later runs see it present.
-      - name: Cache vcpkg installed packages
-        uses: actions/cache@v4
-        with:
-          path: C:\vcpkg\installed
-          key: vcpkg-installed-x64-windows-rel-v2
-
-      - name: Install dependencies (vcpkg)
+      # eigen3 is header-only via vcpkg -- fast even uncached, no need to compile or cache it.
+      - name: Install eigen3 (vcpkg)
         shell: bash
         run: |
-          # MINS dropped PCL, so we only need eigen3, opencv4 and yaml-cpp here.
-          # vcpkg is pre-installed on the runner at $VCPKG_INSTALLATION_ROOT.
-          # x64-windows-rel is our release-only overlay triplet (skips the debug builds).
-          vcpkg install eigen3 opencv4 yaml-cpp \
+          vcpkg install eigen3 \
             --triplet x64-windows-rel --overlay-triplets=.github/vcpkg-triplets
-          cmake --version | head -1
+
+      # vcpkg's opencv4 port compiles OpenCV from source (~30+ min, even with PCL gone).
+      # Use the official prebuilt Windows package instead -- a self-extracting archive with
+      # no compile step, done in well under a minute.
+      - name: Install OpenCV (prebuilt)
+        shell: bash
+        run: |
+          curl -sSL -o opencv.exe https://github.com/opencv/opencv/releases/download/4.10.0/opencv-4.10.0-windows.exe
+          ./opencv.exe -oC:/ -y
+          echo "OPENCV_DIR=C:/opencv/build" >> "$GITHUB_ENV"
 
       - name: Configure
         shell: bash
@@ -47,7 +47,9 @@ jobs:
             -DENABLE_ARUCO_TAGS=OFF \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
             -DVCPKG_TARGET_TRIPLET=x64-windows-rel \
-            -DVCPKG_OVERLAY_TRIPLETS=.github/vcpkg-triplets
+            -DVCPKG_OVERLAY_TRIPLETS=.github/vcpkg-triplets \
+            -DOpenCV_DIR="$OPENCV_DIR" \
+            -DCMAKE_PREFIX_PATH="$OPENCV_DIR"
 
       - name: Build
         shell: bash
@@ -64,8 +66,10 @@ jobs:
         run: |
           set -eo pipefail
           export MINS_ROOT="$PWD"
-          # the vcpkg DLLs (opencv, ...) must be findable at run time
-          export PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-rel/bin:$PATH"
+          # ov_core_lib.dll lives in its own subproject build dir (add_subdirectory target),
+          # and opencv's DLL is in the prebuilt package's bin dir -- both must be on PATH for
+          # mins_cli.exe to load at run time.
+          export PATH="$PWD/build/mins/ov_core/Release:C:/opencv/build/x64/vc16/bin:$PATH"
           # config_system.yaml writes results four levels above $MINS_ROOT/mins
           mkdir -p "$PWD/../../../outputs/tmp/0"
           ./build/mins/Release/mins_cli.exe mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,9 +1,12 @@
 name: Windows Workflow
 
 # Builds the MINS core library + headless CLI natively on Windows (MSVC, x64). No ROS, no
-# Docker, no vcpkg -- PCL is gone and the remaining deps (Eigen, OpenCV) are grabbed directly
-# (header-only install / prebuilt package), so a from-source vcpkg build is no longer needed
-# for this job. Uploads mins_cli.exe, so every build produces a downloadable Windows binary.
+# Docker. PCL is gone, and Eigen is header-only so it installs directly (no vcpkg, no
+# compile). OpenCV still comes from vcpkg -- the official prebuilt OpenCV Windows package
+# only ships binaries for the vc16 toolset family, and this runner's default MSVC toolset
+# has moved past that, so vcpkg (which compiles fresh against whatever toolset is actually
+# present) is the reliable option here even though it's slower. Uploads mins_cli.exe, so
+# every build produces a downloadable Windows binary.
 
 on:
   push:
@@ -32,15 +35,21 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=C:/eigen
           cmake --build eigen-build --target install --config Release
 
-      # vcpkg's opencv4 port compiles OpenCV from source (~30+ min, even with PCL gone -- and
-      # its toolchain file also wraps find_package globally, which fights a manually supplied
-      # OpenCVConfig.cmake). Skip vcpkg for OpenCV entirely: use the official prebuilt Windows
-      # package, a self-extracting archive with no compile step.
-      - name: Install OpenCV (prebuilt)
+      # vcpkg builds opencv from source, matching whatever MSVC toolset this runner actually
+      # has -- unlike a fixed prebuilt package, this stays correct as the runner image's
+      # default toolset moves forward over time. Cache the installed tree so only the first
+      # run after a toolset/version bump pays the full build cost.
+      - name: Cache vcpkg installed packages
+        uses: actions/cache@v4
+        with:
+          path: C:\vcpkg\installed
+          key: vcpkg-installed-x64-windows-rel-opencv-v1
+
+      - name: Install OpenCV (vcpkg)
         shell: bash
         run: |
-          curl -sSL -o opencv.exe https://github.com/opencv/opencv/releases/download/4.10.0/opencv-4.10.0-windows.exe
-          ./opencv.exe -oC:/ -y
+          vcpkg install opencv4 \
+            --triplet x64-windows-rel --overlay-triplets=.github/vcpkg-triplets
 
       - name: Configure
         shell: bash
@@ -50,8 +59,9 @@ jobs:
             -DENABLE_ROS=OFF \
             -DENABLE_ARUCO_TAGS=OFF \
             -DEigen3_DIR="C:/eigen/share/eigen3/cmake" \
-            -DOpenCV_DIR="C:/opencv/build" \
-            -DCMAKE_PREFIX_PATH="C:/opencv/build"
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_TARGET_TRIPLET=x64-windows-rel \
+            -DVCPKG_OVERLAY_TRIPLETS=.github/vcpkg-triplets
 
       - name: Build
         shell: bash
@@ -69,9 +79,9 @@ jobs:
           set -eo pipefail
           export MINS_ROOT="$PWD"
           # ov_core_lib.dll lives in its own subproject build dir (add_subdirectory target),
-          # and opencv's DLL is in the prebuilt package's bin dir -- both must be on PATH for
+          # and opencv's DLL is in vcpkg's installed bin dir -- both must be on PATH for
           # mins_cli.exe to load at run time.
-          export PATH="$PWD/build/mins/ov_core/Release:C:/opencv/build/x64/vc16/bin:$PATH"
+          export PATH="$PWD/build/mins/ov_core/Release:$VCPKG_INSTALLATION_ROOT/installed/x64-windows-rel/bin:$PATH"
           # config_system.yaml writes results four levels above $MINS_ROOT/mins
           mkdir -p "$PWD/../../../outputs/tmp/0"
           ./build/mins/Release/mins_cli.exe mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           curl -sSL -o eigen.zip https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip
           cmake -E tar xf eigen.zip
-          cmake -S eigen-3.4.0 -B eigen-build -G "Visual Studio 17 2022" -A x64 \
+          cmake -S eigen-3.4.0 -B eigen-build \
             -DCMAKE_INSTALL_PREFIX=C:/eigen
           cmake --build eigen-build --target install --config Release
 
@@ -46,7 +46,6 @@ jobs:
         shell: bash
         run: |
           cmake -S mins -B build/mins \
-            -G "Visual Studio 17 2022" -A x64 \
             -DCMAKE_BUILD_TYPE=Release \
             -DENABLE_ROS=OFF \
             -DENABLE_ARUCO_TAGS=OFF \

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,69 @@
+name: Windows Workflow
+
+# Builds the MINS core library + headless CLI natively on Windows (MSVC, x64) with deps from
+# vcpkg. No ROS, no Docker -- this is the only job proving MINS builds on the MSVC toolchain.
+# It uploads mins_cli.exe, so every build produces a downloadable Windows binary.
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_windows:
+    name: "No ROS - Windows (x64)"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies (vcpkg)
+        shell: bash
+        run: |
+          # PCL is the heavy one (pulls boost + flann). vcpkg's pcl port does NOT enable the
+          # visualization feature by default, so no VTK -- same reason we avoid it on macOS.
+          # vcpkg is pre-installed on the runner at $VCPKG_INSTALLATION_ROOT.
+          vcpkg install eigen3 opencv4 pcl yaml-cpp --triplet x64-windows
+          cmake --version | head -1
+
+      - name: Configure
+        shell: bash
+        run: |
+          cmake -S mins -B build/mins \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_ROS=OFF \
+            -DENABLE_ARUCO_TAGS=OFF \
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_TARGET_TRIPLET=x64-windows
+
+      - name: Build
+        shell: bash
+        run: cmake --build build/mins --config Release -j
+
+      - name: Inspect binary
+        shell: bash
+        run: |
+          # MSVC is multi-config: the exe lands in a Release/ subdir.
+          find build -name "mins_cli.exe" -print
+
+      - name: Run headless CLI end to end
+        shell: bash
+        run: |
+          set -eo pipefail
+          export MINS_ROOT="$PWD"
+          # the vcpkg DLLs (opencv, pcl, ...) must be findable at run time
+          export PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin:$PATH"
+          # config_system.yaml writes results four levels above $MINS_ROOT/mins
+          mkdir -p "$PWD/../../../outputs/tmp/0"
+          ./build/mins/Release/mins_cli.exe mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log
+          grep -q "RMSE average" /tmp/cli.log
+
+      - name: Upload Windows binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: mins_cli-windows-x64
+          path: build/mins/Release/mins_cli.exe
+          retention-days: 14

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,4 @@
-name: Windows (x64)
+name: Windows Workflow
 
 # Builds the MINS core library + headless CLI natively on Windows (MSVC, x64) with deps from
 # vcpkg. No ROS, no Docker -- this is the only job proving MINS builds on the MSVC toolchain.
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\vcpkg\installed
-          key: vcpkg-installed-x64-windows-v2
+          key: vcpkg-installed-x64-windows-rel-v1
 
       - name: Install dependencies (vcpkg)
         shell: bash
@@ -34,7 +34,9 @@ jobs:
           # PCL is the heavy one (pulls boost + flann). vcpkg's pcl port does NOT enable the
           # visualization feature by default, so no VTK -- same reason we avoid it on macOS.
           # vcpkg is pre-installed on the runner at $VCPKG_INSTALLATION_ROOT.
-          vcpkg install eigen3 opencv4 pcl yaml-cpp --triplet x64-windows
+          # x64-windows-rel is our release-only overlay triplet (skips the debug builds).
+          vcpkg install eigen3 opencv4 pcl yaml-cpp \
+            --triplet x64-windows-rel --overlay-triplets=.github/vcpkg-triplets
           cmake --version | head -1
 
       - name: Configure
@@ -45,7 +47,8 @@ jobs:
             -DENABLE_ROS=OFF \
             -DENABLE_ARUCO_TAGS=OFF \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-            -DVCPKG_TARGET_TRIPLET=x64-windows
+            -DVCPKG_TARGET_TRIPLET=x64-windows-rel \
+            -DVCPKG_OVERLAY_TRIPLETS=.github/vcpkg-triplets
 
       - name: Build
         shell: bash
@@ -63,7 +66,7 @@ jobs:
           set -eo pipefail
           export MINS_ROOT="$PWD"
           # the vcpkg DLLs (opencv, pcl, ...) must be findable at run time
-          export PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin:$PATH"
+          export PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-rel/bin:$PATH"
           # config_system.yaml writes results four levels above $MINS_ROOT/mins
           mkdir -p "$PWD/../../../outputs/tmp/0"
           ./build/mins/Release/mins_cli.exe mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -20,13 +20,13 @@ jobs:
         with:
           submodules: recursive
 
-      # vcpkg builds PCL (+boost/flann) from source -- ~40 min. Cache its built package
-      # archives so only the first run pays that cost; later runs restore in seconds.
-      - name: Cache vcpkg archives
+      # vcpkg builds PCL (+boost/flann) from source -- ~40 min. Cache the installed tree so
+      # only the first run pays that cost; later runs see the packages already present.
+      - name: Cache vcpkg installed packages
         uses: actions/cache@v4
         with:
-          path: ~/AppData/Local/vcpkg/archives
-          key: vcpkg-x64-windows-v1
+          path: C:\vcpkg\installed
+          key: vcpkg-installed-x64-windows-v2
 
       - name: Install dependencies (vcpkg)
         shell: bash

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,9 +1,10 @@
 # MINS
-[![ROS 1 Workflow](https://github.com/rpng/MINS/actions/workflows/build_ros1.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1.yml)
-[![ROS 2 Workflow](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml)
-[![ROS-free Workflow](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml)
-[![macOS Workflow](https://github.com/rpng/MINS/actions/workflows/build_macos.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_macos.yml)
-[![Windows Workflow](https://github.com/rpng/MINS/actions/workflows/build_windows.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_windows.yml)
+[![ROS1 Melodic (Ubuntu 18.04)](https://github.com/rpng/MINS/actions/workflows/build_ros1_melodic.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1_melodic.yml)
+[![ROS1 Noetic (Ubuntu 20.04)](https://github.com/rpng/MINS/actions/workflows/build_ros1_noetic.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1_noetic.yml)
+[![ROS2 Humble (Ubuntu 22.04)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml)
+[![ROS-free (Ubuntu 22.04)](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml)
+[![macOS (arm64)](https://github.com/rpng/MINS/actions/workflows/build_macos.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_macos.yml)
+[![Windows (x64)](https://github.com/rpng/MINS/actions/workflows/build_windows.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_windows.yml)
 
 An efficient, robust, and tightly-coupled **Multisensor-aided Inertial Navigation System (MINS)** which is capable of 
 flexibly fusing all five sensing modalities (**IMU**, **wheel** **encoders**, **camera**, **GNSS**, and **LiDAR**) in a filtering 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,6 +2,8 @@
 [![ROS 1 Workflow](https://github.com/rpng/MINS/actions/workflows/build_ros1.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1.yml)
 [![ROS 2 Workflow](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml)
 [![ROS-free Workflow](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml)
+[![macOS Workflow](https://github.com/rpng/MINS/actions/workflows/build_macos.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_macos.yml)
+[![Windows Workflow](https://github.com/rpng/MINS/actions/workflows/build_windows.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_windows.yml)
 
 An efficient, robust, and tightly-coupled **Multisensor-aided Inertial Navigation System (MINS)** which is capable of 
 flexibly fusing all five sensing modalities (**IMU**, **wheel** **encoders**, **camera**, **GNSS**, and **LiDAR**) in a filtering 

--- a/mins/CMakeLists.txt
+++ b/mins/CMakeLists.txt
@@ -17,7 +17,9 @@ if (MSVC)
     # Export all symbols so the SHARED libs behave like they do on linux/mac (MSVC hides them otherwise);
     # set before add_subdirectory(ov_core) so ov_core_lib inherits it too.
     add_compile_definitions(NOMINMAX _USE_MATH_DEFINES)
-    add_compile_options(/O2 /EHsc /bigobj)
+    # /FIcassert force-includes <cassert> everywhere: ov_core uses assert() but relies on it
+    # being pulled in transitively, which gcc/clang do and msvc does not.
+    add_compile_options(/O2 /EHsc /bigobj /FIcassert)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else ()
     # Enable compile optimizations

--- a/mins/CMakeLists.txt
+++ b/mins/CMakeLists.txt
@@ -12,11 +12,19 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Suppress unnecessary warnings: https://github.com/PointCloudLibrary/pcl/issues/3680
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
 
-# Enable compile optimizations
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
-
-# Enable debug flags (use if you want to debug in gdb)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
+if (MSVC)
+    # M_PI etc need _USE_MATH_DEFINES; NOMINMAX stops windows.h clobbering std::min/max; /bigobj for heavy templates.
+    # Export all symbols so the SHARED libs behave like they do on linux/mac (MSVC hides them otherwise);
+    # set before add_subdirectory(ov_core) so ov_core_lib inherits it too.
+    add_compile_definitions(NOMINMAX _USE_MATH_DEFINES)
+    add_compile_options(/O2 /EHsc /bigobj)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+else ()
+    # Enable compile optimizations
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
+    # Enable debug flags (use if you want to debug in gdb)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
+endif ()
 
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
@@ -27,12 +35,6 @@ if (NOT OpenCV_FOUND)
 endif ()
 message(STATUS "OPENCV: " ${OpenCV_VERSION})
 message(STATUS "Eigen3: " ${Eigen3_VERSION} " | PCL: " ${PCL_VERSION})
-
-# Enable compile optimizations
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
-
-# Enable debug flags (use if you want to debug in gdb)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
 
 # GCC older than 9.1 needs an explicit lib for std::filesystem (ROS Melodic ships GCC 7.5)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)

--- a/mins/cmake/ROS1.cmake
+++ b/mins/cmake/ROS1.cmake
@@ -21,6 +21,7 @@ include_directories(
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
         ${OpenCV_LIBRARIES}
+        Eigen3::Eigen
         )
 
 # Core (ROS-free) library sources

--- a/mins/src/core/SystemManager.h
+++ b/mins/src/core/SystemManager.h
@@ -39,8 +39,8 @@ template <class PointT> struct PointCloud;
 } // namespace mins
 
 namespace ov_core {
-class ImuData;
-class CameraData;
+struct ImuData;
+struct CameraData;
 } // namespace ov_core
 
 namespace mins {

--- a/mins/src/init/imu_wheel/IW_Initializer.h
+++ b/mins/src/init/imu_wheel/IW_Initializer.h
@@ -29,7 +29,7 @@ using namespace Eigen;
 using namespace std;
 
 namespace ov_core {
-class ImuData;
+struct ImuData;
 }
 
 namespace ov_type {

--- a/mins/src/update/lidar/ikd_Tree.cpp
+++ b/mins/src/update/lidar/ikd_Tree.cpp
@@ -64,7 +64,6 @@ template <typename PointType> void KD_TREE<PointType>::InitTreeNode(KD_TREE_NODE
   root->need_push_down_to_right = false;
   root->point_downsample_deleted = false;
   root->working_flag = false;
-  pthread_mutex_init(&(root->push_down_mutex_lock), NULL);
 }
 
 template <typename PointType> int KD_TREE<PointType>::size() {
@@ -76,9 +75,9 @@ template <typename PointType> int KD_TREE<PointType>::size() {
       return 0;
     }
   } else {
-    if (!pthread_mutex_trylock(&working_flag_mutex)) {
+    if (working_flag_mutex.try_lock()) {
       s = Root_Node->TreeSize;
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
       return s;
     } else {
       return Treesize_tmp;
@@ -100,14 +99,14 @@ template <typename PointType> BoxPointType KD_TREE<PointType>::tree_range() {
       memset(&range, 0, sizeof(range));
     }
   } else {
-    if (!pthread_mutex_trylock(&working_flag_mutex)) {
+    if (working_flag_mutex.try_lock()) {
       range.vertex_min[0] = Root_Node->node_range_x[0];
       range.vertex_min[1] = Root_Node->node_range_y[0];
       range.vertex_min[2] = Root_Node->node_range_z[0];
       range.vertex_max[0] = Root_Node->node_range_x[1];
       range.vertex_max[1] = Root_Node->node_range_y[1];
       range.vertex_max[2] = Root_Node->node_range_z[1];
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     } else {
       memset(&range, 0, sizeof(range));
     }
@@ -123,9 +122,9 @@ template <typename PointType> int KD_TREE<PointType>::validnum() {
     else
       return 0;
   } else {
-    if (!pthread_mutex_trylock(&working_flag_mutex)) {
+    if (working_flag_mutex.try_lock()) {
       s = Root_Node->TreeSize - Root_Node->invalid_point_num;
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
       return s;
     } else {
       return -1;
@@ -139,10 +138,10 @@ template <typename PointType> void KD_TREE<PointType>::root_alpha(float &alpha_b
     alpha_del = Root_Node->alpha_del;
     return;
   } else {
-    if (!pthread_mutex_trylock(&working_flag_mutex)) {
+    if (working_flag_mutex.try_lock()) {
       alpha_bal = Root_Node->alpha_bal;
       alpha_del = Root_Node->alpha_del;
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
       return;
     } else {
       alpha_bal = alpha_bal_tmp;
@@ -153,45 +152,27 @@ template <typename PointType> void KD_TREE<PointType>::root_alpha(float &alpha_b
 }
 
 template <typename PointType> void KD_TREE<PointType>::start_thread() {
-  pthread_mutex_init(&termination_flag_mutex_lock, NULL);
-  pthread_mutex_init(&rebuild_ptr_mutex_lock, NULL);
-  pthread_mutex_init(&rebuild_logger_mutex_lock, NULL);
-  pthread_mutex_init(&points_deleted_rebuild_mutex_lock, NULL);
-  pthread_mutex_init(&working_flag_mutex, NULL);
-  pthread_mutex_init(&search_flag_mutex, NULL);
-  pthread_create(&rebuild_thread, NULL, multi_thread_ptr, (void *)this);
+  rebuild_thread = std::thread(&KD_TREE::multi_thread_rebuild, this);
   //  printf("Multi thread started \n");
 }
 
 template <typename PointType> void KD_TREE<PointType>::stop_thread() {
-  pthread_mutex_lock(&termination_flag_mutex_lock);
+  termination_flag_mutex_lock.lock();
   termination_flag = true;
-  pthread_mutex_unlock(&termination_flag_mutex_lock);
-  if (rebuild_thread)
-    pthread_join(rebuild_thread, NULL);
-  pthread_mutex_destroy(&termination_flag_mutex_lock);
-  pthread_mutex_destroy(&rebuild_logger_mutex_lock);
-  pthread_mutex_destroy(&rebuild_ptr_mutex_lock);
-  pthread_mutex_destroy(&points_deleted_rebuild_mutex_lock);
-  pthread_mutex_destroy(&working_flag_mutex);
-  pthread_mutex_destroy(&search_flag_mutex);
-}
-
-template <typename PointType> void *KD_TREE<PointType>::multi_thread_ptr(void *arg) {
-  KD_TREE *handle = (KD_TREE *)arg;
-  handle->multi_thread_rebuild();
-  return nullptr;
+  termination_flag_mutex_lock.unlock();
+  if (rebuild_thread.joinable())
+    rebuild_thread.join();
 }
 
 template <typename PointType> void KD_TREE<PointType>::multi_thread_rebuild() {
   bool terminated = false;
   KD_TREE_NODE *father_ptr, **new_node_ptr;
-  pthread_mutex_lock(&termination_flag_mutex_lock);
+  termination_flag_mutex_lock.lock();
   terminated = termination_flag;
-  pthread_mutex_unlock(&termination_flag_mutex_lock);
+  termination_flag_mutex_lock.unlock();
   while (!terminated) {
-    pthread_mutex_lock(&rebuild_ptr_mutex_lock);
-    pthread_mutex_lock(&working_flag_mutex);
+    rebuild_ptr_mutex_lock.lock();
+    working_flag_mutex.lock();
     if (Rebuild_Ptr != nullptr) {
       /* Traverse and copy */
       if (!Rebuild_Logger.empty()) {
@@ -208,58 +189,58 @@ template <typename PointType> void KD_TREE<PointType>::multi_thread_rebuild() {
       father_ptr = (*Rebuild_Ptr)->father_ptr;
       PointVector().swap(Rebuild_PCL_Storage);
       // Lock Search
-      pthread_mutex_lock(&search_flag_mutex);
+      search_flag_mutex.lock();
       while (search_mutex_counter != 0) {
-        pthread_mutex_unlock(&search_flag_mutex);
-        usleep(1);
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.unlock();
+        std::this_thread::sleep_for(std::chrono::microseconds(1));
+        search_flag_mutex.lock();
       }
       search_mutex_counter = -1;
-      pthread_mutex_unlock(&search_flag_mutex);
+      search_flag_mutex.unlock();
       // Lock deleted points cache
-      pthread_mutex_lock(&points_deleted_rebuild_mutex_lock);
+      points_deleted_rebuild_mutex_lock.lock();
       flatten(*Rebuild_Ptr, Rebuild_PCL_Storage, MULTI_THREAD_REC);
       // Unlock deleted points cache
-      pthread_mutex_unlock(&points_deleted_rebuild_mutex_lock);
+      points_deleted_rebuild_mutex_lock.unlock();
       // Unlock Search
-      pthread_mutex_lock(&search_flag_mutex);
+      search_flag_mutex.lock();
       search_mutex_counter = 0;
-      pthread_mutex_unlock(&search_flag_mutex);
-      pthread_mutex_unlock(&working_flag_mutex);
+      search_flag_mutex.unlock();
+      working_flag_mutex.unlock();
       /* Rebuild and update missed operations*/
       Operation_Logger_Type Operation;
       KD_TREE_NODE *new_root_node = nullptr;
       if (int(Rebuild_PCL_Storage.size()) > 0) {
         BuildTree(&new_root_node, 0, Rebuild_PCL_Storage.size() - 1, Rebuild_PCL_Storage);
         // Rebuild has been done. Updates the blocked operations into the new tree
-        pthread_mutex_lock(&working_flag_mutex);
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        working_flag_mutex.lock();
+        rebuild_logger_mutex_lock.lock();
         int tmp_counter = 0;
         while (!Rebuild_Logger.empty()) {
           Operation = Rebuild_Logger.front();
           max_queue_size = max(max_queue_size, Rebuild_Logger.size());
           Rebuild_Logger.pop();
-          pthread_mutex_unlock(&rebuild_logger_mutex_lock);
-          pthread_mutex_unlock(&working_flag_mutex);
+          rebuild_logger_mutex_lock.unlock();
+          working_flag_mutex.unlock();
           run_operation(&new_root_node, Operation);
           tmp_counter++;
           if (tmp_counter % 10 == 0)
-            usleep(1);
-          pthread_mutex_lock(&working_flag_mutex);
-          pthread_mutex_lock(&rebuild_logger_mutex_lock);
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
+          working_flag_mutex.lock();
+          rebuild_logger_mutex_lock.lock();
         }
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
       /* Replace to original tree*/
-      // pthread_mutex_lock(&working_flag_mutex);
-      pthread_mutex_lock(&search_flag_mutex);
+      // working_flag_mutex.lock();
+      search_flag_mutex.lock();
       while (search_mutex_counter != 0) {
-        pthread_mutex_unlock(&search_flag_mutex);
-        usleep(1);
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.unlock();
+        std::this_thread::sleep_for(std::chrono::microseconds(1));
+        search_flag_mutex.lock();
       }
       search_mutex_counter = -1;
-      pthread_mutex_unlock(&search_flag_mutex);
+      search_flag_mutex.unlock();
       if (father_ptr->left_son_ptr == *Rebuild_Ptr) {
         father_ptr->left_son_ptr = new_root_node;
       } else if (father_ptr->right_son_ptr == *Rebuild_Ptr) {
@@ -285,22 +266,22 @@ template <typename PointType> void KD_TREE<PointType>::multi_thread_rebuild() {
           break;
         Update(update_root);
       }
-      pthread_mutex_lock(&search_flag_mutex);
+      search_flag_mutex.lock();
       search_mutex_counter = 0;
-      pthread_mutex_unlock(&search_flag_mutex);
+      search_flag_mutex.unlock();
       Rebuild_Ptr = nullptr;
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
       rebuild_flag = false;
       /* Delete discarded tree nodes */
       delete_tree_nodes(&old_root_node);
     } else {
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
-    pthread_mutex_unlock(&rebuild_ptr_mutex_lock);
-    pthread_mutex_lock(&termination_flag_mutex_lock);
+    rebuild_ptr_mutex_lock.unlock();
+    termination_flag_mutex_lock.lock();
     terminated = termination_flag;
-    pthread_mutex_unlock(&termination_flag_mutex_lock);
-    usleep(100);
+    termination_flag_mutex_lock.unlock();
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
   }
   //  printf("Rebuild thread terminated normally\n");
 }
@@ -364,18 +345,18 @@ void KD_TREE<PointType>::Nearest_Search(PointType point, int k_nearest, PointVec
   if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != Root_Node) {
     Search(Root_Node, k_nearest, point, q, max_dist);
   } else {
-    pthread_mutex_lock(&search_flag_mutex);
+    search_flag_mutex.lock();
     while (search_mutex_counter == -1) {
-      pthread_mutex_unlock(&search_flag_mutex);
-      usleep(1);
-      pthread_mutex_lock(&search_flag_mutex);
+      search_flag_mutex.unlock();
+      std::this_thread::sleep_for(std::chrono::microseconds(1));
+      search_flag_mutex.lock();
     }
     search_mutex_counter += 1;
-    pthread_mutex_unlock(&search_flag_mutex);
+    search_flag_mutex.unlock();
     Search(Root_Node, k_nearest, point, q, max_dist);
-    pthread_mutex_lock(&search_flag_mutex);
+    search_flag_mutex.lock();
     search_mutex_counter -= 1;
-    pthread_mutex_unlock(&search_flag_mutex);
+    search_flag_mutex.unlock();
   }
   int k_found = min(k_nearest, int(q.size()));
   PointVector().swap(Nearest_Points);
@@ -442,19 +423,19 @@ template <typename PointType> int KD_TREE<PointType>::Add_Points(PointVector &Po
           operation_delete.op = DOWNSAMPLE_DELETE;
           operation.point = downsample_result;
           operation.op = ADD_POINT;
-          pthread_mutex_lock(&working_flag_mutex);
+          working_flag_mutex.lock();
           if (Downsample_Storage.size() > 0)
             Delete_by_range(&Root_Node, Box_of_Point, false, true);
           Add_by_point(&Root_Node, downsample_result, false, Root_Node->division_axis);
           tmp_counter++;
           if (rebuild_flag) {
-            pthread_mutex_lock(&rebuild_logger_mutex_lock);
+            rebuild_logger_mutex_lock.lock();
             if (Downsample_Storage.size() > 0)
               Rebuild_Logger.push(operation_delete);
             Rebuild_Logger.push(operation);
-            pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+            rebuild_logger_mutex_lock.unlock();
           }
-          pthread_mutex_unlock(&working_flag_mutex);
+          working_flag_mutex.unlock();
         };
       }
     } else {
@@ -464,14 +445,14 @@ template <typename PointType> int KD_TREE<PointType>::Add_Points(PointVector &Po
         Operation_Logger_Type operation;
         operation.point = PointToAdd[i];
         operation.op = ADD_POINT;
-        pthread_mutex_lock(&working_flag_mutex);
+        working_flag_mutex.lock();
         Add_by_point(&Root_Node, PointToAdd[i], false, Root_Node->division_axis);
         if (rebuild_flag) {
-          pthread_mutex_lock(&rebuild_logger_mutex_lock);
+          rebuild_logger_mutex_lock.lock();
           Rebuild_Logger.push(operation);
-          pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+          rebuild_logger_mutex_lock.unlock();
         }
-        pthread_mutex_unlock(&working_flag_mutex);
+        working_flag_mutex.unlock();
       }
     }
   }
@@ -486,14 +467,14 @@ template <typename PointType> void KD_TREE<PointType>::Add_Point_Boxes(vector<Bo
       Operation_Logger_Type operation;
       operation.boxpoint = BoxPoints[i];
       operation.op = ADD_BOX;
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       Add_by_range(&Root_Node, BoxPoints[i], false);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(operation);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   return;
@@ -507,14 +488,14 @@ template <typename PointType> void KD_TREE<PointType>::Delete_Points(PointVector
       Operation_Logger_Type operation;
       operation.point = PointToDel[i];
       operation.op = DELETE_POINT;
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       Delete_by_point(&Root_Node, PointToDel[i], false);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(operation);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   return;
@@ -529,21 +510,21 @@ template <typename PointType> int KD_TREE<PointType>::Delete_Point_Boxes(vector<
       Operation_Logger_Type operation;
       operation.boxpoint = BoxPoints[i];
       operation.op = DELETE_BOX;
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       tmp_counter += Delete_by_range(&Root_Node, BoxPoints[i], false, false);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(operation);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   return tmp_counter;
 }
 
 template <typename PointType> void KD_TREE<PointType>::acquire_removed_points(PointVector &removed_points) {
-  pthread_mutex_lock(&points_deleted_rebuild_mutex_lock);
+  points_deleted_rebuild_mutex_lock.lock();
   for (int i = 0; i < Points_deleted.size(); i++) {
     removed_points.push_back(Points_deleted[i]);
   }
@@ -552,7 +533,7 @@ template <typename PointType> void KD_TREE<PointType>::acquire_removed_points(Po
   }
   Points_deleted.clear();
   Multithread_Points_deleted.clear();
-  pthread_mutex_unlock(&points_deleted_rebuild_mutex_lock);
+  points_deleted_rebuild_mutex_lock.unlock();
   return;
 }
 
@@ -612,11 +593,11 @@ template <typename PointType> void KD_TREE<PointType>::BuildTree(KD_TREE_NODE **
 template <typename PointType> void KD_TREE<PointType>::Rebuild(KD_TREE_NODE **root) {
   KD_TREE_NODE *father_ptr;
   if ((*root)->TreeSize >= Multi_Thread_Rebuild_Point_Num) {
-    if (!pthread_mutex_trylock(&rebuild_ptr_mutex_lock)) {
+    if (rebuild_ptr_mutex_lock.try_lock()) {
       if (Rebuild_Ptr == nullptr || ((*root)->TreeSize > (*Rebuild_Ptr)->TreeSize)) {
         Rebuild_Ptr = root;
       }
-      pthread_mutex_unlock(&rebuild_ptr_mutex_lock);
+      rebuild_ptr_mutex_lock.unlock();
     }
   } else {
     father_ptr = (*root)->father_ptr;
@@ -680,26 +661,26 @@ int KD_TREE<PointType>::Delete_by_range(KD_TREE_NODE **root, BoxPointType boxpoi
   if ((Rebuild_Ptr == nullptr) || (*root)->left_son_ptr != *Rebuild_Ptr) {
     tmp_counter += Delete_by_range(&((*root)->left_son_ptr), boxpoint, allow_rebuild, is_downsample);
   } else {
-    pthread_mutex_lock(&working_flag_mutex);
+    working_flag_mutex.lock();
     tmp_counter += Delete_by_range(&((*root)->left_son_ptr), boxpoint, false, is_downsample);
     if (rebuild_flag) {
-      pthread_mutex_lock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.lock();
       Rebuild_Logger.push(delete_box_log);
-      pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.unlock();
     }
-    pthread_mutex_unlock(&working_flag_mutex);
+    working_flag_mutex.unlock();
   }
   if ((Rebuild_Ptr == nullptr) || (*root)->right_son_ptr != *Rebuild_Ptr) {
     tmp_counter += Delete_by_range(&((*root)->right_son_ptr), boxpoint, allow_rebuild, is_downsample);
   } else {
-    pthread_mutex_lock(&working_flag_mutex);
+    working_flag_mutex.lock();
     tmp_counter += Delete_by_range(&((*root)->right_son_ptr), boxpoint, false, is_downsample);
     if (rebuild_flag) {
-      pthread_mutex_lock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.lock();
       Rebuild_Logger.push(delete_box_log);
-      pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.unlock();
     }
-    pthread_mutex_unlock(&working_flag_mutex);
+    working_flag_mutex.unlock();
   }
   Update(*root);
   if (Rebuild_Ptr != nullptr && *Rebuild_Ptr == *root && (*root)->TreeSize < Multi_Thread_Rebuild_Point_Num)
@@ -733,27 +714,27 @@ template <typename PointType> void KD_TREE<PointType>::Delete_by_point(KD_TREE_N
     if ((Rebuild_Ptr == nullptr) || (*root)->left_son_ptr != *Rebuild_Ptr) {
       Delete_by_point(&(*root)->left_son_ptr, point, allow_rebuild);
     } else {
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       Delete_by_point(&(*root)->left_son_ptr, point, false);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(delete_log);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   } else {
     if ((Rebuild_Ptr == nullptr) || (*root)->right_son_ptr != *Rebuild_Ptr) {
       Delete_by_point(&(*root)->right_son_ptr, point, allow_rebuild);
     } else {
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       Delete_by_point(&(*root)->right_son_ptr, point, false);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(delete_log);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   Update(*root);
@@ -800,26 +781,26 @@ template <typename PointType> void KD_TREE<PointType>::Add_by_range(KD_TREE_NODE
   if ((Rebuild_Ptr == nullptr) || (*root)->left_son_ptr != *Rebuild_Ptr) {
     Add_by_range(&((*root)->left_son_ptr), boxpoint, allow_rebuild);
   } else {
-    pthread_mutex_lock(&working_flag_mutex);
+    working_flag_mutex.lock();
     Add_by_range(&((*root)->left_son_ptr), boxpoint, false);
     if (rebuild_flag) {
-      pthread_mutex_lock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.lock();
       Rebuild_Logger.push(add_box_log);
-      pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.unlock();
     }
-    pthread_mutex_unlock(&working_flag_mutex);
+    working_flag_mutex.unlock();
   }
   if ((Rebuild_Ptr == nullptr) || (*root)->right_son_ptr != *Rebuild_Ptr) {
     Add_by_range(&((*root)->right_son_ptr), boxpoint, allow_rebuild);
   } else {
-    pthread_mutex_lock(&working_flag_mutex);
+    working_flag_mutex.lock();
     Add_by_range(&((*root)->right_son_ptr), boxpoint, false);
     if (rebuild_flag) {
-      pthread_mutex_lock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.lock();
       Rebuild_Logger.push(add_box_log);
-      pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+      rebuild_logger_mutex_lock.unlock();
     }
-    pthread_mutex_unlock(&working_flag_mutex);
+    working_flag_mutex.unlock();
   }
   Update(*root);
   if (Rebuild_Ptr != nullptr && *Rebuild_Ptr == *root && (*root)->TreeSize < Multi_Thread_Rebuild_Point_Num)
@@ -853,27 +834,27 @@ void KD_TREE<PointType>::Add_by_point(KD_TREE_NODE **root, PointType point, bool
     if ((Rebuild_Ptr == nullptr) || (*root)->left_son_ptr != *Rebuild_Ptr) {
       Add_by_point(&(*root)->left_son_ptr, point, allow_rebuild, (*root)->division_axis);
     } else {
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       Add_by_point(&(*root)->left_son_ptr, point, false, (*root)->division_axis);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(add_log);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   } else {
     if ((Rebuild_Ptr == nullptr) || (*root)->right_son_ptr != *Rebuild_Ptr) {
       Add_by_point(&(*root)->right_son_ptr, point, allow_rebuild, (*root)->division_axis);
     } else {
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       Add_by_point(&(*root)->right_son_ptr, point, false, (*root)->division_axis);
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(add_log);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   Update(*root);
@@ -895,15 +876,13 @@ void KD_TREE<PointType>::Search(KD_TREE_NODE *root, int k_nearest, PointType poi
   double max_dist_sqr = max_dist * max_dist;
   if (cur_dist > max_dist_sqr)
     return;
-  int retval;
   if (root->need_push_down_to_left || root->need_push_down_to_right) {
-    retval = pthread_mutex_trylock(&(root->push_down_mutex_lock));
-    if (retval == 0) {
+    if (root->push_down_mutex_lock.try_lock()) {
       Push_Down(root);
-      pthread_mutex_unlock(&(root->push_down_mutex_lock));
+      root->push_down_mutex_lock.unlock();
     } else {
-      pthread_mutex_lock(&(root->push_down_mutex_lock));
-      pthread_mutex_unlock(&(root->push_down_mutex_lock));
+      root->push_down_mutex_lock.lock();
+      root->push_down_mutex_lock.unlock();
     }
   }
   if (!root->point_deleted) {
@@ -923,70 +902,70 @@ void KD_TREE<PointType>::Search(KD_TREE_NODE *root, int k_nearest, PointType poi
       if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != root->left_son_ptr) {
         Search(root->left_son_ptr, k_nearest, point, q, max_dist);
       } else {
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         while (search_mutex_counter == -1) {
-          pthread_mutex_unlock(&search_flag_mutex);
-          usleep(1);
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.unlock();
+          std::this_thread::sleep_for(std::chrono::microseconds(1));
+          search_flag_mutex.lock();
         }
         search_mutex_counter += 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
         Search(root->left_son_ptr, k_nearest, point, q, max_dist);
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         search_mutex_counter -= 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
       }
       if (q.size() < k_nearest || dist_right_node < q.top().dist) {
         if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != root->right_son_ptr) {
           Search(root->right_son_ptr, k_nearest, point, q, max_dist);
         } else {
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.lock();
           while (search_mutex_counter == -1) {
-            pthread_mutex_unlock(&search_flag_mutex);
-            usleep(1);
-            pthread_mutex_lock(&search_flag_mutex);
+            search_flag_mutex.unlock();
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
+            search_flag_mutex.lock();
           }
           search_mutex_counter += 1;
-          pthread_mutex_unlock(&search_flag_mutex);
+          search_flag_mutex.unlock();
           Search(root->right_son_ptr, k_nearest, point, q, max_dist);
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.lock();
           search_mutex_counter -= 1;
-          pthread_mutex_unlock(&search_flag_mutex);
+          search_flag_mutex.unlock();
         }
       }
     } else {
       if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != root->right_son_ptr) {
         Search(root->right_son_ptr, k_nearest, point, q, max_dist);
       } else {
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         while (search_mutex_counter == -1) {
-          pthread_mutex_unlock(&search_flag_mutex);
-          usleep(1);
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.unlock();
+          std::this_thread::sleep_for(std::chrono::microseconds(1));
+          search_flag_mutex.lock();
         }
         search_mutex_counter += 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
         Search(root->right_son_ptr, k_nearest, point, q, max_dist);
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         search_mutex_counter -= 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
       }
       if (q.size() < k_nearest || dist_left_node < q.top().dist) {
         if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != root->left_son_ptr) {
           Search(root->left_son_ptr, k_nearest, point, q, max_dist);
         } else {
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.lock();
           while (search_mutex_counter == -1) {
-            pthread_mutex_unlock(&search_flag_mutex);
-            usleep(1);
-            pthread_mutex_lock(&search_flag_mutex);
+            search_flag_mutex.unlock();
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
+            search_flag_mutex.lock();
           }
           search_mutex_counter += 1;
-          pthread_mutex_unlock(&search_flag_mutex);
+          search_flag_mutex.unlock();
           Search(root->left_son_ptr, k_nearest, point, q, max_dist);
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.lock();
           search_mutex_counter -= 1;
-          pthread_mutex_unlock(&search_flag_mutex);
+          search_flag_mutex.unlock();
         }
       }
     }
@@ -995,36 +974,36 @@ void KD_TREE<PointType>::Search(KD_TREE_NODE *root, int k_nearest, PointType poi
       if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != root->left_son_ptr) {
         Search(root->left_son_ptr, k_nearest, point, q, max_dist);
       } else {
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         while (search_mutex_counter == -1) {
-          pthread_mutex_unlock(&search_flag_mutex);
-          usleep(1);
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.unlock();
+          std::this_thread::sleep_for(std::chrono::microseconds(1));
+          search_flag_mutex.lock();
         }
         search_mutex_counter += 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
         Search(root->left_son_ptr, k_nearest, point, q, max_dist);
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         search_mutex_counter -= 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
       }
     }
     if (dist_right_node < q.top().dist) {
       if (Rebuild_Ptr == nullptr || *Rebuild_Ptr != root->right_son_ptr) {
         Search(root->right_son_ptr, k_nearest, point, q, max_dist);
       } else {
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         while (search_mutex_counter == -1) {
-          pthread_mutex_unlock(&search_flag_mutex);
-          usleep(1);
-          pthread_mutex_lock(&search_flag_mutex);
+          search_flag_mutex.unlock();
+          std::this_thread::sleep_for(std::chrono::microseconds(1));
+          search_flag_mutex.lock();
         }
         search_mutex_counter += 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
         Search(root->right_son_ptr, k_nearest, point, q, max_dist);
-        pthread_mutex_lock(&search_flag_mutex);
+        search_flag_mutex.lock();
         search_mutex_counter -= 1;
-        pthread_mutex_unlock(&search_flag_mutex);
+        search_flag_mutex.unlock();
       }
     }
   }
@@ -1055,16 +1034,16 @@ template <typename PointType> void KD_TREE<PointType>::Search_by_range(KD_TREE_N
   if ((Rebuild_Ptr == nullptr) || root->left_son_ptr != *Rebuild_Ptr) {
     Search_by_range(root->left_son_ptr, boxpoint, Storage);
   } else {
-    pthread_mutex_lock(&search_flag_mutex);
+    search_flag_mutex.lock();
     Search_by_range(root->left_son_ptr, boxpoint, Storage);
-    pthread_mutex_unlock(&search_flag_mutex);
+    search_flag_mutex.unlock();
   }
   if ((Rebuild_Ptr == nullptr) || root->right_son_ptr != *Rebuild_Ptr) {
     Search_by_range(root->right_son_ptr, boxpoint, Storage);
   } else {
-    pthread_mutex_lock(&search_flag_mutex);
+    search_flag_mutex.lock();
     Search_by_range(root->right_son_ptr, boxpoint, Storage);
-    pthread_mutex_unlock(&search_flag_mutex);
+    search_flag_mutex.unlock();
   }
   return;
 }
@@ -1091,16 +1070,16 @@ void KD_TREE<PointType>::Search_by_radius(KD_TREE_NODE *root, PointType point, f
   if ((Rebuild_Ptr == nullptr) || root->left_son_ptr != *Rebuild_Ptr) {
     Search_by_radius(root->left_son_ptr, point, radius, Storage);
   } else {
-    pthread_mutex_lock(&search_flag_mutex);
+    search_flag_mutex.lock();
     Search_by_radius(root->left_son_ptr, point, radius, Storage);
-    pthread_mutex_unlock(&search_flag_mutex);
+    search_flag_mutex.unlock();
   }
   if ((Rebuild_Ptr == nullptr) || root->right_son_ptr != *Rebuild_Ptr) {
     Search_by_radius(root->right_son_ptr, point, radius, Storage);
   } else {
-    pthread_mutex_lock(&search_flag_mutex);
+    search_flag_mutex.lock();
     Search_by_radius(root->right_son_ptr, point, radius, Storage);
-    pthread_mutex_unlock(&search_flag_mutex);
+    search_flag_mutex.unlock();
   }
   return;
 }
@@ -1148,7 +1127,7 @@ template <typename PointType> void KD_TREE<PointType>::Push_Down(KD_TREE_NODE *r
       root->left_son_ptr->need_push_down_to_right = true;
       root->need_push_down_to_left = false;
     } else {
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       root->left_son_ptr->tree_downsample_deleted |= root->tree_downsample_deleted;
       root->left_son_ptr->point_downsample_deleted |= root->tree_downsample_deleted;
       root->left_son_ptr->tree_deleted = root->tree_deleted || root->left_son_ptr->tree_downsample_deleted;
@@ -1162,12 +1141,12 @@ template <typename PointType> void KD_TREE<PointType>::Push_Down(KD_TREE_NODE *r
       root->left_son_ptr->need_push_down_to_left = true;
       root->left_son_ptr->need_push_down_to_right = true;
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(operation);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
       root->need_push_down_to_left = false;
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   if (root->need_push_down_to_right && root->right_son_ptr != nullptr) {
@@ -1186,7 +1165,7 @@ template <typename PointType> void KD_TREE<PointType>::Push_Down(KD_TREE_NODE *r
       root->right_son_ptr->need_push_down_to_right = true;
       root->need_push_down_to_right = false;
     } else {
-      pthread_mutex_lock(&working_flag_mutex);
+      working_flag_mutex.lock();
       root->right_son_ptr->tree_downsample_deleted |= root->tree_downsample_deleted;
       root->right_son_ptr->point_downsample_deleted |= root->tree_downsample_deleted;
       root->right_son_ptr->tree_deleted = root->tree_deleted || root->right_son_ptr->tree_downsample_deleted;
@@ -1200,12 +1179,12 @@ template <typename PointType> void KD_TREE<PointType>::Push_Down(KD_TREE_NODE *r
       root->right_son_ptr->need_push_down_to_left = true;
       root->right_son_ptr->need_push_down_to_right = true;
       if (rebuild_flag) {
-        pthread_mutex_lock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.lock();
         Rebuild_Logger.push(operation);
-        pthread_mutex_unlock(&rebuild_logger_mutex_lock);
+        rebuild_logger_mutex_lock.unlock();
       }
       root->need_push_down_to_right = false;
-      pthread_mutex_unlock(&working_flag_mutex);
+      working_flag_mutex.unlock();
     }
   }
   return;
@@ -1392,7 +1371,6 @@ template <typename PointType> void KD_TREE<PointType>::delete_tree_nodes(KD_TREE
   delete_tree_nodes(&(*root)->left_son_ptr);
   delete_tree_nodes(&(*root)->right_son_ptr);
 
-  pthread_mutex_destroy(&(*root)->push_down_mutex_lock);
   delete *root;
   *root = nullptr;
 

--- a/mins/src/update/lidar/ikd_Tree.h
+++ b/mins/src/update/lidar/ikd_Tree.h
@@ -11,12 +11,12 @@
 #include <chrono>
 #include <math.h>
 #include <memory>
+#include <mutex>
+#include <thread>
 #include <pcl/point_types.h>
-#include <pthread.h>
 #include <queue>
 #include <stdio.h>
 #include <time.h>
-#include <unistd.h>
 
 #define EPSS 1e-6
 #define Minimal_Unbalanced_Tree_Size 10
@@ -79,7 +79,7 @@ public:
     bool need_push_down_to_right = false;
     bool working_flag = false;
     float radius_sq;
-    pthread_mutex_t push_down_mutex_lock;
+    std::mutex push_down_mutex_lock;
     float node_range_x[2], node_range_y[2], node_range_z[2];
     KD_TREE_NODE *left_son_ptr = nullptr;
     KD_TREE_NODE *right_son_ptr = nullptr;
@@ -186,15 +186,14 @@ private:
   // Multi-thread Tree Rebuild
   bool termination_flag = false;
   bool rebuild_flag = false;
-  pthread_t rebuild_thread;
-  pthread_mutex_t termination_flag_mutex_lock, rebuild_ptr_mutex_lock, working_flag_mutex, search_flag_mutex;
-  pthread_mutex_t rebuild_logger_mutex_lock, points_deleted_rebuild_mutex_lock;
+  std::thread rebuild_thread;
+  std::mutex termination_flag_mutex_lock, rebuild_ptr_mutex_lock, working_flag_mutex, search_flag_mutex;
+  std::mutex rebuild_logger_mutex_lock, points_deleted_rebuild_mutex_lock;
   // queue<Operation_Logger_Type> Rebuild_Logger;
   MANUAL_Q<Operation_Logger_Type> Rebuild_Logger;
   PointVector Rebuild_PCL_Storage;
   KD_TREE_NODE **Rebuild_Ptr = nullptr;
   int search_mutex_counter = 0;
-  static void *multi_thread_ptr(void *arg);
   void multi_thread_rebuild();
   void start_thread();
   void stop_thread();

--- a/mins/src/utils/Print_Logger.h
+++ b/mins/src/utils/Print_Logger.h
@@ -95,10 +95,10 @@ private:
  * The different Types of print levels
  */
 // Get the file name directly https://stackoverflow.com/questions/8487986/file-macro-shows-full-path
-#define PRINT0(x...) mins::Print_Logger::debugPrint(0, __FILE__, TOSTRING(__LINE__), x)
-#define PRINT1(x...) mins::Print_Logger::debugPrint(1, __FILE__, TOSTRING(__LINE__), x)
-#define PRINT2(x...) mins::Print_Logger::debugPrint(2, __FILE__, TOSTRING(__LINE__), x)
-#define PRINT3(x...) mins::Print_Logger::debugPrint(3, __FILE__, TOSTRING(__LINE__), x)
-#define PRINT4(x...) mins::Print_Logger::debugPrint(4, __FILE__, TOSTRING(__LINE__), x)
+#define PRINT0(...) mins::Print_Logger::debugPrint(0, __FILE__, TOSTRING(__LINE__), __VA_ARGS__)
+#define PRINT1(...) mins::Print_Logger::debugPrint(1, __FILE__, TOSTRING(__LINE__), __VA_ARGS__)
+#define PRINT2(...) mins::Print_Logger::debugPrint(2, __FILE__, TOSTRING(__LINE__), __VA_ARGS__)
+#define PRINT3(...) mins::Print_Logger::debugPrint(3, __FILE__, TOSTRING(__LINE__), __VA_ARGS__)
+#define PRINT4(...) mins::Print_Logger::debugPrint(4, __FILE__, TOSTRING(__LINE__), __VA_ARGS__)
 #define PRINTLINE printf("%s:%d\n", strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__, __LINE__);
 #endif /* mins_PRINT_H */

--- a/thirdparty/open_vins/ov_core/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_core/CMakeLists.txt
@@ -39,11 +39,12 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Enable compile optimizations
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
-
-# Enable debug flags (use if you want to debug in gdb)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
+# Enable compile optimizations (GCC/Clang only; MSVC gets its flags from the parent mins project)
+if (NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
+    # Enable debug flags (use if you want to debug in gdb)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
+endif ()
 
 # Find our ROS version!
 # NOTE: Default to using the ROS1 package if both are in our enviroment

--- a/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
@@ -85,6 +85,7 @@ if (catkin_FOUND AND ENABLE_ROS)
 
 endif ()
 
+if (NOT WIN32)  # test_webcam/test_profile use unistd.h (POSIX); not needed for MINS
 add_executable(test_webcam src/test_webcam.cpp)
 target_link_libraries(test_webcam ov_core_lib ${thirdparty_libraries})
 install(TARGETS test_webcam
@@ -100,6 +101,8 @@ install(TARGETS test_profile
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+endif ()
 
 
 

--- a/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS1.cmake
@@ -32,6 +32,7 @@ include_directories(
 list(APPEND thirdparty_libraries
         ${OpenCV_LIBRARIES}
         ${catkin_LIBRARIES}
+        Eigen3::Eigen
 )
 
 ##################################################

--- a/thirdparty/open_vins/ov_core/src/utils/opencv_yaml_parse.h
+++ b/thirdparty/open_vins/ov_core/src/utils/opencv_yaml_parse.h
@@ -107,7 +107,7 @@ public:
    * @brief Will get the folder this config file is in
    * @return Config folder
    */
-  std::string get_config_folder() { return config_path_.substr(0, config_path_.find_last_of('/')) + "/"; }
+  std::string get_config_folder() { return config_path_.substr(0, config_path_.find_last_of("/\\")) + "/"; }
 
   /**
    * @brief Check to see if all parameters were read succesfully
@@ -597,7 +597,7 @@ private:
       std::exit(EXIT_FAILURE);
     }
     (*config)[external_node_name] >> path;
-    std::string relative_folder = config_path_.substr(0, config_path_.find_last_of('/')) + "/";
+    std::string relative_folder = config_path_.substr(0, config_path_.find_last_of("/\\")) + "/";
 
     // Now actually try to load them from file!
     auto config_external = std::make_shared<cv::FileStorage>(relative_folder + path, cv::FileStorage::READ);

--- a/thirdparty/open_vins/ov_core/src/utils/print.h
+++ b/thirdparty/open_vins/ov_core/src/utils/print.h
@@ -93,10 +93,10 @@ private:
 /*
  * The different Types of print levels
  */
-#define PRINT_ALL(x...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::ALL, __FILE__, TOSTRING(__LINE__), x);
-#define PRINT_DEBUG(x...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::DEBUG, __FILE__, TOSTRING(__LINE__), x);
-#define PRINT_INFO(x...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::INFO, __FILE__, TOSTRING(__LINE__), x);
-#define PRINT_WARNING(x...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::WARNING, __FILE__, TOSTRING(__LINE__), x);
-#define PRINT_ERROR(x...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::ERROR, __FILE__, TOSTRING(__LINE__), x);
+#define PRINT_ALL(...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::ALL, __FILE__, TOSTRING(__LINE__), __VA_ARGS__);
+#define PRINT_DEBUG(...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::DEBUG, __FILE__, TOSTRING(__LINE__), __VA_ARGS__);
+#define PRINT_INFO(...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::INFO, __FILE__, TOSTRING(__LINE__), __VA_ARGS__);
+#define PRINT_WARNING(...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::WARNING, __FILE__, TOSTRING(__LINE__), __VA_ARGS__);
+#define PRINT_ERROR(...) ov_core::Printer::debugPrint(ov_core::Printer::PrintLevel::ERROR, __FILE__, TOSTRING(__LINE__), __VA_ARGS__);
 
 #endif /* OV_CORE_PRINT_H */


### PR DESCRIPTION
Native Windows (MSVC, x64) build of the ROS-free CLI, plus the ikd_Tree threading port that unblocks it.

- **ikd_Tree**: pthread -> std::thread/std::mutex (pthread has no MSVC equivalent). Mechanical 1:1 swap, verified with a lidar sim run, RMSE unchanged 0.255/0.142.
- **CMake**: guard GCC/Clang-only flags behind NOT MSVC; give MSVC its own flags + NOMINMAX/_USE_MATH_DEFINES + export-all-symbols.
- **CI**: new windows-latest job, deps via vcpkg, builds + smoke-runs mins_cli.exe and uploads it. A downloadable Windows binary next to the macOS one.

First Windows run will be slow (vcpkg compiles PCL). Linux/mac builds verified locally, unchanged.