### PR TITLE
drop pcl: in-house pointcloud + direct ros pointcloud2 conversion

### DIFF
--- a/mins/CMakeLists.txt
+++ b/mins/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT OpenCV_FOUND)
     find_package(OpenCV 3 REQUIRED QUIET)
 endif ()
 message(STATUS "OPENCV: " ${OpenCV_VERSION})
-message(STATUS "Eigen3: " ${Eigen3_VERSION} " | PCL: " ${PCL_VERSION})
+message(STATUS "Eigen3: " ${Eigen3_VERSION})
 
 # Enable compile optimizations
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")

--- a/mins/cmake/ROS1.cmake
+++ b/mins/cmake/ROS1.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS1 (catkin). QUIET (not REQUIRED) so this same file can also configure a
 # ROS-free build of the core library when catkin is not present.
-find_package(catkin QUIET COMPONENTS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs image_geometry visualization_msgs image_transport cv_bridge ov_core pcl_ros)
+find_package(catkin QUIET COMPONENTS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs image_geometry visualization_msgs image_transport cv_bridge ov_core)
 option(ENABLE_ROS "Build the ROS integration and nodes when ROS is found" ON)
 
 # When ROS is absent, ov_core (normally a catkin package) is pulled in as a subproject.
@@ -67,11 +67,11 @@ if (catkin_FOUND AND ENABLE_ROS)
 
     # Add catkin packages
     catkin_package(
-            CATKIN_DEPENDS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs image_geometry visualization_msgs image_transport cv_bridge ov_core pcl_ros
+            CATKIN_DEPENDS roscpp rosbag tf std_msgs geometry_msgs sensor_msgs nav_msgs image_geometry visualization_msgs image_transport cv_bridge ov_core
             INCLUDE_DIRS src/
             LIBRARIES mins_lib
     )
-    include_directories(${catkin_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
+    include_directories(${catkin_INCLUDE_DIRS})
     list(APPEND thirdparty_libraries ${catkin_LIBRARIES})
 
     # ROS integration lives at the boundary - compiled in only when we have ROS
@@ -89,15 +89,9 @@ else ()
     set(CATKIN_PACKAGE_BIN_DESTINATION "${CMAKE_INSTALL_BINDIR}")
     set(CATKIN_GLOBAL_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mins/")
 
-    # ov_core was pulled in above (before LIBRARY_SOURCES); just link + find PCL here.
-    # (In a ROS build PCL comes via catkin/pcl_ros; standalone we link it ourselves.)
-    # Only the components we actually use: point types + transforms (common) and VoxelGrid
-    # (filters). Asking for all of PCL drags in pcl_visualization -> VTK, which we never use.
-    find_package(PCL REQUIRED COMPONENTS common filters)
-    include_directories(${PCL_INCLUDE_DIRS})
-    link_directories(${PCL_LIBRARY_DIRS})
-    add_definitions(${PCL_DEFINITIONS})
-    list(APPEND thirdparty_libraries ov_core_lib ${PCL_LIBRARIES})
+    # ov_core was pulled in above (before LIBRARY_SOURCES); just link it here.
+    # No PCL: MINS uses its own point cloud types now (update/lidar/PointCloud.h).
+    list(APPEND thirdparty_libraries ov_core_lib)
 endif ()
 
 ##################################################

--- a/mins/cmake/ROS2.cmake
+++ b/mins/cmake/ROS2.cmake
@@ -16,14 +16,12 @@ find_package(image_geometry REQUIRED)  # Might require additional setup
 find_package(visualization_msgs REQUIRED)
 find_package(image_transport REQUIRED)  # Might require additional setup
 find_package(cv_bridge REQUIRED)        # Might require additional setup
-find_package(pcl_conversions REQUIRED)
 
 # Other dependencies (if available through ROS 2 packages)
-# find_package(pcl_ros2 REQUIRED)  # Might require building ROS 2 wrapper for PCL
 find_package(ov_core REQUIRED)   # Might not be available as a ROS 2 package
 
 add_definitions(-DROS_AVAILABLE=2)
-ament_export_dependencies(rclcpp rosbag2 tf2_ros std_msgs geometry_msgs sensor_msgs nav_msgs std_srvs image_geometry visualization_msgs image_transport cv_bridge ov_core pcl_conversions)
+ament_export_dependencies(rclcpp rosbag2 tf2_ros std_msgs geometry_msgs sensor_msgs nav_msgs std_srvs image_geometry visualization_msgs image_transport cv_bridge ov_core)
 # ament_export_include_directories(src/)
 ament_export_libraries(mins_lib)
 
@@ -40,7 +38,6 @@ list(APPEND ament_libraries
         cv_bridge
         image_transport
         ov_core
-        pcl_conversions
         image_geometry
 )
 
@@ -54,7 +51,6 @@ include_directories(
 # Set link libraries used by all binaries
 list(APPEND thirdparty_libraries
         ${OpenCV_LIBRARIES}
-        ${PCL_LIBRARIES}
         )
 
 ##################################################

--- a/mins/package.xml
+++ b/mins/package.xml
@@ -34,7 +34,6 @@
     <depend>image_transport</depend>
     <depend>cv_bridge</depend>
     <depend>ov_core</depend>
-    <depend>pcl_ros</depend>
 
     <!-- Note the export is required to expose the executables -->
     <export>

--- a/mins/src/core/ROS2Helper.cpp
+++ b/mins/src/core/ROS2Helper.cpp
@@ -26,8 +26,9 @@
  */
 
 #include "ROS2Helper.h"
+#include "update/lidar/PointCloud2Convert.h"
 #include "options/OptionsCamera.h"
-#include "pcl_conversions/pcl_conversions.h"
+#include "update/lidar/PointCloud.h"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "sensor_msgs/point_cloud2_iterator.hpp"
@@ -133,9 +134,8 @@ ov_core::ImuData ROS2Helper::Imu2Data(const sensor_msgs::msg::Imu::SharedPtr msg
   return message;
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> ROS2Helper::rosPC2pclPC(const sensor_msgs::msg::PointCloud2::SharedPtr msg, int id) {
-  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> pcl_pc2(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::fromROSMsg(*msg, *pcl_pc2);
+std::shared_ptr<mins::PointCloud<mins::PointXYZ>> ROS2Helper::rosPC2pclPC(const sensor_msgs::msg::PointCloud2::SharedPtr msg, int id) {
+  auto pcl_pc2 = mins::fromPC2(*msg);
   pcl_pc2->header.frame_id = to_string(id);                                 // overwrite the id match with system number
   pcl_pc2->header.stamp = rclcpp::Time(msg->header.stamp).seconds() * 1000; // deliver this in msec
   return pcl_pc2;

--- a/mins/src/core/ROS2Helper.h
+++ b/mins/src/core/ROS2Helper.h
@@ -29,6 +29,12 @@
 #define MINS_ROSVISUALIZER_HELPER_H
 
 #include "rclcpp/rclcpp.hpp"
+// forward decls - full PointCloud.h only needed in .cpp files that build/read clouds
+namespace mins {
+struct PointXYZ;
+struct PointXYZI;
+template <class PointT> struct PointCloud;
+} // namespace mins
 #include <Eigen/Eigen>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -55,7 +61,6 @@ struct Vec;
 } // namespace ov_type
 namespace pcl {
 class PointXYZ;
-template <class pointT> class PointCloud;
 } // namespace pcl
 
 namespace mins {
@@ -96,7 +101,7 @@ public:
 
   static GPSData PoseStamped2Data(const geometry_msgs::msg::PoseStamped::SharedPtr msg, int id, double noise);
 
-  static std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> rosPC2pclPC(const sensor_msgs::msg::PointCloud2::SharedPtr msg, int id);
+  static std::shared_ptr<mins::PointCloud<mins::PointXYZ>> rosPC2pclPC(const sensor_msgs::msg::PointCloud2::SharedPtr msg, int id);
 
   static GPSData NavSatFix2Data(const sensor_msgs::msg::NavSatFix::SharedPtr msg, int id);
 

--- a/mins/src/core/ROS2Publisher.cpp
+++ b/mins/src/core/ROS2Publisher.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "ROS2Publisher.h"
+#include "update/lidar/PointCloud2Convert.h"
 #include "ROS2Helper.h"
 #include "SystemManager.h"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
@@ -39,7 +40,7 @@
 #include "options/OptionsLidar.h"
 #include "options/OptionsVicon.h"
 #include "options/OptionsWheel.h"
-#include "pcl_conversions/pcl_conversions.h"
+#include "update/lidar/PointCloud.h"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "state/Propagator.h"
 #include "state/State.h"
@@ -57,7 +58,6 @@
 #include "utils/Print_Logger.h"
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.hpp>
-#include <pcl/common/transforms.h>
 #include <tf2_ros/transform_broadcaster.h>
 
 using namespace std;
@@ -419,9 +419,9 @@ void ROS2Publisher::publish_vicon(ViconData data) {
   seq_vicon[data.id]++;
 }
 
-void ROS2Publisher::publish_lidar_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar) {
+void ROS2Publisher::publish_lidar_cloud(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar) {
   sensor_msgs::msg::PointCloud2 output;
-  pcl::toROSMsg(*lidar, output);
+  mins::toPC2(*lidar, output);
   output.header.frame_id = "lidar" + lidar->header.frame_id;
   output.header.stamp = rclcpp::Clock().now();
   pub_lidar_cloud.at(stoi(lidar->header.frame_id))->publish(output);
@@ -485,18 +485,18 @@ void ROS2Publisher::publish_lidar_map() {
 
     // Publish pointcloud in the global frame
     // This is slower because it requires pointcloud transform
-    POINTCLOUD_XYZI_PTR map_inL(new pcl::PointCloud<pcl::PointXYZI>);
+    POINTCLOUD_XYZI_PTR map_inL(new mins::PointCloud<mins::PointXYZI>);
     ikd->tree->flatten(ikd->tree->Root_Node, map_inL->points, NOT_RECORD);
     pair<Matrix3d, Vector3d> pose_LinG = sys->up_ldr->get_pose_LinG(ikd->id, ikd->time);
     Matrix4d tr = Matrix4d::Identity();
     tr.block(0, 0, 3, 3) = pose_LinG.first.transpose();
     tr.block(0, 3, 3, 1) = pose_LinG.second;
-    POINTCLOUD_XYZI_PTR map_inG(new pcl::PointCloud<pcl::PointXYZI>);
+    POINTCLOUD_XYZI_PTR map_inG(new mins::PointCloud<mins::PointXYZI>);
     map_inL->height = map_inL->points.size();
     map_inL->width = 1;
-    pcl::transformPointCloud(*map_inL, *map_inG, tr);
+    mins::transformPointCloud(*map_inL, *map_inG, tr);
     sensor_msgs::msg::PointCloud2 map_pointcloud;
-    pcl::toROSMsg(*map_inG, map_pointcloud);
+    mins::toPC2(*map_inG, map_pointcloud);
     map_pointcloud.header.frame_id = "global";
     map_pointcloud.header.stamp = rclcpp::Clock().now();
     pub_lidar_map.at(ikd->id)->publish(map_pointcloud);

--- a/mins/src/core/ROS2Publisher.h
+++ b/mins/src/core/ROS2Publisher.h
@@ -29,6 +29,12 @@
 #define MINS_ROSPUBLISHER_H
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
+// forward decls - full PointCloud.h only needed in .cpp files that build/read clouds
+namespace mins {
+struct PointXYZ;
+struct PointXYZI;
+template <class PointT> struct PointCloud;
+} // namespace mins
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "nav_msgs/msg/path.hpp"
@@ -41,7 +47,6 @@
 
 namespace pcl {
 class PointXYZ;
-template <class pointT> class PointCloud;
 } // namespace pcl
 
 namespace mins {
@@ -76,7 +81,7 @@ public:
   void publish_cam_images(int cam_id);
 
   /// Publish lidar point cloud
-  void publish_lidar_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar);
+  void publish_lidar_cloud(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar);
 
   void reset_paths();
 

--- a/mins/src/core/ROS2Subscriber.cpp
+++ b/mins/src/core/ROS2Subscriber.cpp
@@ -216,7 +216,7 @@ void ROS2Subscriber::callback_gnss(const NavSatFix::SharedPtr msg, int gps_id) {
 
 void ROS2Subscriber::callback_lidar(const PointCloud2::SharedPtr msg, int lidar_id) {
   // convert into correct format & send it to our system
-  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> data = ROS2Helper::rosPC2pclPC(msg, lidar_id);
+  std::shared_ptr<mins::PointCloud<mins::PointXYZ>> data = ROS2Helper::rosPC2pclPC(msg, lidar_id);
   sys->feed_measurement_lidar(data);
   pub->publish_lidar_cloud(data);
   PRINT1(YELLOW "[SUB] LiDAR measurement: %.3f|%d\n" RESET, (double)msg->header.stamp.sec / 1000, lidar_id);

--- a/mins/src/core/ROSHelper.cpp
+++ b/mins/src/core/ROSHelper.cpp
@@ -26,8 +26,9 @@
  */
 
 #include "ROSHelper.h"
+#include "update/lidar/PointCloud2Convert.h"
 #include "options/OptionsCamera.h"
-#include "pcl_conversions/pcl_conversions.h"
+#include "update/lidar/PointCloud.h"
 #include "state/State.h"
 #include "types/PoseJPL.h"
 #include "types/Vec.h"
@@ -116,9 +117,8 @@ ov_core::ImuData ROSHelper::Imu2Data(const Imu::ConstPtr &msg) {
   return message;
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> ROSHelper::rosPC2pclPC(const sensor_msgs::PointCloud2ConstPtr &msg, int id) {
-  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> pcl_pc2(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::fromROSMsg(*msg, *pcl_pc2);
+std::shared_ptr<mins::PointCloud<mins::PointXYZ>> ROSHelper::rosPC2pclPC(const sensor_msgs::PointCloud2ConstPtr &msg, int id) {
+  auto pcl_pc2 = mins::fromPC2(*msg);
   pcl_pc2->header.frame_id = to_string(id);                 // overwrite the id match with system number
   pcl_pc2->header.stamp = msg->header.stamp.toSec() * 1000; // deliver this in msec
   return pcl_pc2;

--- a/mins/src/core/ROSHelper.h
+++ b/mins/src/core/ROSHelper.h
@@ -29,6 +29,12 @@
 #define MINS_ROSVISUALIZER_HELPER_H
 
 #include <Eigen/Eigen>
+// forward decls - full PointCloud.h only needed in .cpp files that build/read clouds
+namespace mins {
+struct PointXYZ;
+struct PointXYZI;
+template <class PointT> struct PointCloud;
+} // namespace mins
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <sensor_msgs/CompressedImage.h>
@@ -52,7 +58,6 @@ struct Vec;
 } // namespace ov_type
 namespace pcl {
 class PointXYZ;
-template <class pointT> class PointCloud;
 } // namespace pcl
 
 namespace mins {
@@ -89,7 +94,7 @@ public:
 
   static GPSData PoseStamped2Data(const geometry_msgs::PoseStampedPtr &msg, int id, double noise);
 
-  static std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> rosPC2pclPC(const sensor_msgs::PointCloud2ConstPtr &msg, int id);
+  static std::shared_ptr<mins::PointCloud<mins::PointXYZ>> rosPC2pclPC(const sensor_msgs::PointCloud2ConstPtr &msg, int id);
 
   static GPSData NavSatFix2Data(const sensor_msgs::NavSatFixPtr &msg, int id);
 

--- a/mins/src/core/ROSPublisher.cpp
+++ b/mins/src/core/ROSPublisher.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "ROSPublisher.h"
+#include "update/lidar/PointCloud2Convert.h"
 #include "ROSHelper.h"
 #include "SystemManager.h"
 #include "geometry_msgs/PoseWithCovarianceStamped.h"
@@ -39,7 +40,7 @@
 #include "options/OptionsLidar.h"
 #include "options/OptionsVicon.h"
 #include "options/OptionsWheel.h"
-#include "pcl_conversions/pcl_conversions.h"
+#include "update/lidar/PointCloud.h"
 #include "sensor_msgs/PointCloud2.h"
 #include "state/Propagator.h"
 #include "state/State.h"
@@ -57,7 +58,6 @@
 #include "utils/Print_Logger.h"
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
-#include <pcl/common/transforms.h>
 #include <tf/transform_broadcaster.h>
 
 using namespace std;
@@ -419,9 +419,9 @@ void ROSPublisher::publish_vicon(ViconData data) {
   seq_vicon[data.id]++;
 }
 
-void ROSPublisher::publish_lidar_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar) {
+void ROSPublisher::publish_lidar_cloud(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar) {
   sensor_msgs::PointCloud2 output;
-  pcl::toROSMsg(*lidar, output);
+  mins::toPC2(*lidar, output);
   output.header.frame_id = "lidar" + lidar->header.frame_id;
   output.header.stamp = ros::Time::now();
   pub_lidar_cloud.at(stoi(lidar->header.frame_id)).publish(output);
@@ -465,18 +465,18 @@ void ROSPublisher::publish_lidar_map() {
 
     // Publish pointcloud in the global frame
     // This is slower because it requires pointcloud transform
-    POINTCLOUD_XYZI_PTR map_inL(new pcl::PointCloud<pcl::PointXYZI>);
+    POINTCLOUD_XYZI_PTR map_inL(new mins::PointCloud<mins::PointXYZI>);
     ikd->tree->flatten(ikd->tree->Root_Node, map_inL->points, NOT_RECORD);
     pair<Matrix3d, Vector3d> pose_LinG = sys->up_ldr->get_pose_LinG(ikd->id, ikd->time);
     Matrix4d tr = Matrix4d::Identity();
     tr.block(0, 0, 3, 3) = pose_LinG.first.transpose();
     tr.block(0, 3, 3, 1) = pose_LinG.second;
-    POINTCLOUD_XYZI_PTR map_inG(new pcl::PointCloud<pcl::PointXYZI>);
+    POINTCLOUD_XYZI_PTR map_inG(new mins::PointCloud<mins::PointXYZI>);
     map_inL->height = map_inL->points.size();
     map_inL->width = 1;
-    pcl::transformPointCloud(*map_inL, *map_inG, tr);
+    mins::transformPointCloud(*map_inL, *map_inG, tr);
     sensor_msgs::PointCloud2 map_pointcloud;
-    pcl::toROSMsg(*map_inG, map_pointcloud);
+    mins::toPC2(*map_inG, map_pointcloud);
     map_pointcloud.header.frame_id = "global";
     map_pointcloud.header.stamp = ros::Time::now();
     pub_lidar_map.at(ikd->id).publish(map_pointcloud);

--- a/mins/src/core/ROSPublisher.h
+++ b/mins/src/core/ROSPublisher.h
@@ -29,6 +29,12 @@
 #define MINS_ROSPUBLISHER_H
 
 #include "geometry_msgs/PoseStamped.h"
+// forward decls - full PointCloud.h only needed in .cpp files that build/read clouds
+namespace mins {
+struct PointXYZ;
+struct PointXYZI;
+template <class PointT> struct PointCloud;
+} // namespace mins
 #include "ros/ros.h"
 #include <image_transport/image_transport.h>
 #include <memory>
@@ -46,7 +52,6 @@ class TransformBroadcaster;
 }
 namespace pcl {
 class PointXYZ;
-template <class pointT> class PointCloud;
 } // namespace pcl
 
 namespace mins {
@@ -81,7 +86,7 @@ public:
   void publish_cam_images(int cam_id);
 
   /// Publish lidar point cloud
-  void publish_lidar_cloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar);
+  void publish_lidar_cloud(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar);
 
 private:
   /// Publish the current state

--- a/mins/src/core/ROSSubscriber.cpp
+++ b/mins/src/core/ROSSubscriber.cpp
@@ -185,7 +185,7 @@ void ROSSubscriber::callback_gnss(const NavSatFixConstPtr &msg, int gps_id) {
 
 void ROSSubscriber::callback_lidar(const PointCloud2ConstPtr &msg, int lidar_id) {
   // convert into correct format & send it to our system
-  std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> data = ROSHelper::rosPC2pclPC(msg, lidar_id);
+  std::shared_ptr<mins::PointCloud<mins::PointXYZ>> data = ROSHelper::rosPC2pclPC(msg, lidar_id);
   sys->feed_measurement_lidar(data);
   pub->publish_lidar_cloud(data);
   PRINT1(YELLOW "[SUB] LiDAR measurement: %.3f|%d\n" RESET, (double)msg->header.stamp.toSec() / 1000, lidar_id);

--- a/mins/src/core/SystemManager.cpp
+++ b/mins/src/core/SystemManager.cpp
@@ -51,9 +51,7 @@
 #include "update/wheel/WheelTypes.h"
 #include "utils/Jabdongsani.h"
 #include "utils/TimeChecker.h"
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
+#include "update/lidar/PointCloud.h"
 using namespace std;
 using namespace mins;
 
@@ -179,7 +177,7 @@ void SystemManager::feed_measurement_wheel(const WheelData &wheel) {
 }
 
 
-void SystemManager::feed_measurement_lidar(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar) {
+void SystemManager::feed_measurement_lidar(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar) {
   if (!state->op->lidar->enabled)
     return;
   state->initialized ? tc_sensors->ding("LDR") : void();

--- a/mins/src/core/SystemManager.h
+++ b/mins/src/core/SystemManager.h
@@ -31,10 +31,12 @@
 #include <Eigen/Eigen>
 #include <memory>
 
-namespace pcl {
-class PointXYZ;
-template <class pointT> class PointCloud;
-} // namespace pcl
+// forward decls - full PointCloud.h only needed in .cpp files that build/read clouds
+namespace mins {
+struct PointXYZ;
+struct PointXYZI;
+template <class PointT> struct PointCloud;
+} // namespace mins
 
 namespace ov_core {
 class ImuData;
@@ -96,7 +98,7 @@ public:
   void feed_measurement_tlio(const TLIOData &tlio);
 
   /// LiDAR measurement feeder
-  void feed_measurement_lidar(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar);
+  void feed_measurement_lidar(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar);
   /**
    * @brief After the run has ended, print results
    */

--- a/mins/src/init/Initializer.cpp
+++ b/mins/src/init/Initializer.cpp
@@ -55,9 +55,7 @@
 #include "utils/Print_Logger.h"
 #include "utils/TimeChecker.h"
 #include "utils/dataset_reader.h"
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
+#include "update/lidar/PointCloud.h"
 using namespace std;
 using namespace Eigen;
 using namespace mins;
@@ -321,7 +319,7 @@ void Initializer::init_lidar_sim() {
     }
 
     // Get the lidar point cloud
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar(new mins::PointCloud<mins::PointXYZ>);
     bool success = sim->get_lidar_pointcloud(lidar, sim->timestamp - op->dt.at(i), i, op);
     assert(success);
 

--- a/mins/src/run_bag.cpp
+++ b/mins/src/run_bag.cpp
@@ -48,8 +48,7 @@
 #include "utils/opencv_yaml_parse.h"
 #include <geometry_msgs/PoseStamped.h>
 #include <memory>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
+#include "update/lidar/PointCloud.h"
 #include <ros/ros.h>
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
@@ -169,7 +168,7 @@ int main(int argc, char **argv) {
     if (op->est->lidar->enabled) {
       for (int lidar_id = 0; lidar_id < op->est->lidar->max_n; lidar_id++) {
         if (msgs.at(i).getTopic() == op->est->lidar->topic.at(lidar_id)) {
-          std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> data = ROSHelper::rosPC2pclPC(msgs.at(i).instantiate<sensor_msgs::PointCloud2>(), lidar_id);
+          std::shared_ptr<mins::PointCloud<mins::PointXYZ>> data = ROSHelper::rosPC2pclPC(msgs.at(i).instantiate<sensor_msgs::PointCloud2>(), lidar_id);
           PRINT1("[BAG] LDR measurement: %.3f|%d|%d\n", (double)data->header.stamp / 1000, lidar_id, data->points.size());
           sys->feed_measurement_lidar(data);
           pub->publish_lidar_cloud(data);

--- a/mins/src/run_simulation.cpp
+++ b/mins/src/run_simulation.cpp
@@ -56,8 +56,7 @@
 #include "utils/colors.h"
 #include "utils/opencv_yaml_parse.h"
 #include "utils/sensor_data.h"
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
+#include "update/lidar/PointCloud.h"
 
 using namespace mins;
 using namespace std;
@@ -122,7 +121,7 @@ int main(int argc, char **argv) {
     }
 
     // LIDAR: get the next simulated lidar range measurements
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar(new mins::PointCloud<mins::PointXYZ>);
     if (sim->get_next_lidar(lidar)) {
       sys->feed_measurement_lidar(lidar);
       pub->publish_lidar_cloud(lidar);

--- a/mins/src/run_simulation_cli.cpp
+++ b/mins/src/run_simulation_cli.cpp
@@ -49,9 +49,7 @@
 #include "utils/colors.h"
 #include "utils/opencv_yaml_parse.h"
 #include "utils/sensor_data.h"
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
+#include "update/lidar/PointCloud.h"
 using namespace mins;
 using namespace std;
 using namespace Eigen;
@@ -114,7 +112,7 @@ int main(int argc, char **argv) {
     if (sim->get_next_wheel(wheel))
       sys->feed_measurement_wheel(wheel);
 
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar(new pcl::PointCloud<pcl::PointXYZ>);
+    std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar(new mins::PointCloud<mins::PointXYZ>);
     if (sim->get_next_lidar(lidar))
       sys->feed_measurement_lidar(lidar);
 

--- a/mins/src/sim/Simulator.cpp
+++ b/mins/src/sim/Simulator.cpp
@@ -47,9 +47,7 @@
 #include "utils/dataset_reader.h"
 #include "utils/quat_ops.h"
 #include <memory>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
+#include "update/lidar/PointCloud.h"
 using namespace std;
 using namespace ov_core;
 using namespace mins;
@@ -718,7 +716,7 @@ bool Simulator::get_next_wheel(WheelData &wheel) {
   return true;
 }
 
-bool Simulator::get_next_lidar(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar) {
+bool Simulator::get_next_lidar(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar) {
 
   // check turn
   string sensor_type;
@@ -739,7 +737,7 @@ bool Simulator::get_next_lidar(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> l
   return true;
 }
 
-bool Simulator::get_lidar_pointcloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar, double time, int id, std::shared_ptr<OptionsLidar> lidar_op) {
+bool Simulator::get_lidar_pointcloud(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar, double time, int id, std::shared_ptr<OptionsLidar> lidar_op) {
   // Lidar id and timestamp
   lidar->header.frame_id = to_string(id);
   lidar->header.stamp = (unsigned long)((time - lidar_op->dt.at(id)) * 1000); // Delivered in micro second
@@ -794,7 +792,7 @@ bool Simulator::get_lidar_pointcloud(std::shared_ptr<pcl::PointCloud<pcl::PointX
         continue;
 
       // create point
-      pcl::PointXYZ p;
+      mins::PointXYZ p;
       p.x = d * sin(ph) * cos(th);
       p.y = d * sin(ph) * sin(th);
       p.z = d * cos(ph);

--- a/mins/src/sim/Simulator.h
+++ b/mins/src/sim/Simulator.h
@@ -38,10 +38,7 @@ namespace ov_core {
 struct ImuData;
 }
 
-namespace pcl {
-class PointXYZ;
-template <class pointT> class PointCloud;
-} // namespace pcl
+#include "update/lidar/PointCloud.h"
 
 using namespace Eigen;
 namespace mins {
@@ -122,7 +119,7 @@ public:
    * @param lidar mins::LidarData
    * @return True if we have a measurement
    */
-  bool get_next_lidar(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar);
+  bool get_next_lidar(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar);
 
   /// boolean for transforming groundtruth after GPS initialization
   bool trans_gt_to_ENU = false;
@@ -186,7 +183,7 @@ protected:
   bool load_plane_data(std::string path_planes);
 
   /// Generate LiDAR pointcloud
-  bool get_lidar_pointcloud(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar, double time, int id, std::shared_ptr<OptionsLidar> lidar_op);
+  bool get_lidar_pointcloud(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar, double time, int id, std::shared_ptr<OptionsLidar> lidar_op);
 
   /**
    * @brief Will generate points in the fov of the specified camera

--- a/mins/src/update/lidar/LidarHelper.cpp
+++ b/mins/src/update/lidar/LidarHelper.cpp
@@ -23,16 +23,12 @@
 #include "ikd_Tree.h"
 #include "options/OptionsEstimator.h"
 #include "options/OptionsLidar.h"
-#include "pcl/point_cloud.h"
-#include "pcl/point_types.h"
+#include "update/lidar/PointCloud.h"
 #include "state/State.h"
 #include "types/PoseJPL.h"
 #include "utils/Jabdongsani.h"
 #include "utils/Print_Logger.h"
 #include "utils/colors.h"
-#include <pcl/common/transforms.h>
-#include <pcl/filters/voxel_grid.h>
-
 using namespace mins;
 using namespace ov_type;
 
@@ -87,17 +83,11 @@ bool LidarHelper::remove_motion_blur(shared_ptr<State> state, shared_ptr<LiDARDa
 }
 
 void LidarHelper::downsample(shared_ptr<LiDARData> lidar, double downsample_size) {
-  pcl::VoxelGrid<pcl::PointXYZI> downSizeFilter;
-  downSizeFilter.setLeafSize((float)downsample_size, (float)downsample_size, (float)downsample_size);
-  downSizeFilter.setInputCloud((*lidar->pointcloud).makeShared());
-  downSizeFilter.filter(*lidar->pointcloud);
+  mins::voxel_downsample(*lidar->pointcloud, *lidar->pointcloud, (float)downsample_size);
 }
 
 void LidarHelper::downsample(POINTCLOUD_XYZI_PTR lidar, double downsample_size) {
-  pcl::VoxelGrid<pcl::PointXYZI> downSizeFilter;
-  downSizeFilter.setLeafSize((float)downsample_size, (float)downsample_size, (float)downsample_size);
-  downSizeFilter.setInputCloud((*lidar).makeShared());
-  downSizeFilter.filter(*lidar);
+  mins::voxel_downsample(*lidar, *lidar, (float)downsample_size);
 }
 
 void LidarHelper::init_map_local(const shared_ptr<LiDARData> &lidar_inL, shared_ptr<iKDDATA> ikd, shared_ptr<OptionsLidar> op, bool prop) {
@@ -161,7 +151,7 @@ bool LidarHelper::transform_to_map(shared_ptr<State> state, shared_ptr<LiDARData
   //===================================================================
   // Register new scan
   //===================================================================
-  pcl::transformPointCloud(*(lidar->pointcloud), *(lidar->pointcloud_in_map), lidar->T_LtoM);
+  mins::transformPointCloud(*(lidar->pointcloud), *(lidar->pointcloud_in_map), lidar->T_LtoM);
   return true;
 }
 
@@ -171,8 +161,8 @@ void LidarHelper::register_scan(shared_ptr<State> state, shared_ptr<LiDARData> l
 
   // If we have successful ICP, use the info to register the scan in the map
   if (lidar->icp_success) {
-    pcl::PointCloud<pcl::PointXYZI> tr_points;
-    pcl::transformPointCloud(*(lidar->pointcloud_original), tr_points, lidar->T_LtoM);
+    mins::PointCloud<mins::PointXYZI> tr_points;
+    mins::transformPointCloud(*(lidar->pointcloud_original), tr_points, lidar->T_LtoM);
     ikd->tree->Add_Points(tr_points.points, state->op->lidar->map_do_downsample);
     ikd->last_up_time = lidar->time;
   }
@@ -181,7 +171,7 @@ void LidarHelper::register_scan(shared_ptr<State> state, shared_ptr<LiDARData> l
 void LidarHelper::propagate_map_to_newest_clone(shared_ptr<State> state, shared_ptr<iKDDATA> ikd, shared_ptr<OptionsLidar> op, double FT) {
 
   // Load map info
-  POINTCLOUD_XYZI_PTR map_points = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  POINTCLOUD_XYZI_PTR map_points = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
   ikd->tree->flatten(ikd->tree->Root_Node, map_points->points, NOT_RECORD);
   op->map_do_downsample ? downsample(map_points, state->op->lidar->map_downsample_size) : void();
 
@@ -230,17 +220,17 @@ void LidarHelper::propagate_map_to_newest_clone(shared_ptr<State> state, shared_
   tr.block(0, 3, 3, 1) = pLoldinLnew;
 
   // transform the pointcloud
-  pcl::transformPointCloud(*lidar_inM->pointcloud, *lidar_inM->pointcloud, tr);
+  mins::transformPointCloud(*lidar_inM->pointcloud, *lidar_inM->pointcloud, tr);
   lidar_inM->id = ikd->id;
   lidar_inM->time = state->newest_clone_time() - dt;
 
   init_map_local(lidar_inM, ikd, state->op->lidar, true);
 }
 
-bool LidarHelper::get_neighbors(Vector3d pfinM, POINTCLOUD_XYZI_PTR neighbors, shared_ptr<KD_TREE<pcl::PointXYZI>> tree, shared_ptr<OptionsLidar> op) {
+bool LidarHelper::get_neighbors(Vector3d pfinM, POINTCLOUD_XYZI_PTR neighbors, shared_ptr<KD_TREE<mins::PointXYZI>> tree, shared_ptr<OptionsLidar> op) {
   // Transform the point to map to find neighbors from the map.
   // Note "_" mean pcl variable
-  pcl::PointXYZI pfinM_;
+  mins::PointXYZI pfinM_;
   pfinM_.x = pfinM(0);
   pfinM_.y = pfinM(1);
   pfinM_.z = pfinM(2);
@@ -290,7 +280,7 @@ bool LidarHelper::compute_plane(Vector4d &plane_abcd, POINTCLOUD_XYZI_PTR pointc
   // sanity check
   Vector4d pl = plane_abcd / plane_abcd.head(3).norm();
   for (int j = 0; j < (int)pointcloud->size(); j++) {
-    pcl::PointXYZI pt = pointcloud->points[j];
+    mins::PointXYZI pt = pointcloud->points[j];
     if (fabs(pl(0) * pt.x + pl(1) * pt.y + pl(2) * pt.z + pl(3)) > op->plane_max_p2pd) {
       return false;
     }

--- a/mins/src/update/lidar/LidarHelper.h
+++ b/mins/src/update/lidar/LidarHelper.h
@@ -26,12 +26,8 @@
 using namespace std;
 using namespace Eigen;
 
-namespace pcl {
-class PointXYZ;
-class PointXYZI;
-template <class pointT> class PointCloud;
-} // namespace pcl
-typedef std::shared_ptr<pcl::PointCloud<pcl::PointXYZI>> POINTCLOUD_XYZI_PTR;
+#include "update/lidar/PointCloud.h"
+typedef std::shared_ptr<mins::PointCloud<mins::PointXYZI>> POINTCLOUD_XYZI_PTR;
 template <class pointT> class KD_TREE;
 namespace mins {
 class State;
@@ -61,7 +57,7 @@ public:
   static void propagate_map_to_newest_clone(shared_ptr<State> state, shared_ptr<iKDDATA> ikd, shared_ptr<OptionsLidar> op, double FT);
 
   /// Get neighbors with checks
-  static bool get_neighbors(Vector3d pfinM, POINTCLOUD_XYZI_PTR neighbors, shared_ptr<KD_TREE<pcl::PointXYZI>> tree, shared_ptr<OptionsLidar> op);
+  static bool get_neighbors(Vector3d pfinM, POINTCLOUD_XYZI_PTR neighbors, shared_ptr<KD_TREE<mins::PointXYZI>> tree, shared_ptr<OptionsLidar> op);
 
   /// compute the plane information with given pointcloud
   static bool compute_plane(Vector4d &plane_abcd, POINTCLOUD_XYZI_PTR pointcloud, shared_ptr<OptionsLidar> op);

--- a/mins/src/update/lidar/LidarTypes.cpp
+++ b/mins/src/update/lidar/LidarTypes.cpp
@@ -20,17 +20,16 @@
 
 #include "LidarTypes.h"
 #include "ikd_Tree.h"
-#include "pcl/point_cloud.h"
-
+#include "update/lidar/PointCloud.h"
 using namespace mins;
-LiDARData::LiDARData(double time, double ref_time, int id, std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> pointcloud, double max_range, double min_range) : time(time), id(id) {
+LiDARData::LiDARData(double time, double ref_time, int id, std::shared_ptr<mins::PointCloud<mins::PointXYZ>> pointcloud, double max_range, double min_range) : time(time), id(id) {
   // copy over the point cloud
   // copy measurement time of the point so that it can be filtered with time.
   // Note: we only store relative time to "reference time" because intensity (float) has only 4 bytes
   // Note: this "reference time" should be the same for all other pointclouds.
-  this->pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  this->pointcloud_original = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  this->pointcloud_in_map = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  this->pointcloud = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
+  this->pointcloud_original = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
+  this->pointcloud_in_map = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
   this->pointcloud->points.reserve(pointcloud->points.size());
   this->pointcloud_original->points.reserve(pointcloud->points.size());
   for (int i = 0; i < (int)pointcloud->size(); i++) {
@@ -40,14 +39,14 @@ LiDARData::LiDARData(double time, double ref_time, int id, std::shared_ptr<pcl::
       continue;
 
     // Copy
-    this->pointcloud->push_back(pcl::PointXYZI());
+    this->pointcloud->push_back(mins::PointXYZI());
     this->pointcloud->back().x = pointcloud->points[i].x;
     this->pointcloud->back().y = pointcloud->points[i].y;
     this->pointcloud->back().z = pointcloud->points[i].z;
     this->pointcloud->back().intensity = time - ref_time;
 
     // Copy
-    this->pointcloud_original->push_back(pcl::PointXYZI());
+    this->pointcloud_original->push_back(mins::PointXYZI());
     this->pointcloud_original->back().x = pointcloud->points[i].x;
     this->pointcloud_original->back().y = pointcloud->points[i].y;
     this->pointcloud_original->back().z = pointcloud->points[i].z;
@@ -58,9 +57,9 @@ LiDARData::LiDARData(double time, double ref_time, int id, std::shared_ptr<pcl::
 LiDARData::LiDARData() {
   time = -1;
   id = -1;
-  pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  pointcloud_original = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  pointcloud_in_map = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
+  pointcloud = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
+  pointcloud_original = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
+  pointcloud_in_map = std::make_shared<mins::PointCloud<mins::PointXYZI>>();
 }
 
 Eigen::Vector3d LiDARData::p(int p_id) {
@@ -77,6 +76,6 @@ Eigen::Vector3d LiDARData::pfinM(int p_id) {
 int LiDARData::size() { return pointcloud->size(); }
 
 iKDDATA::iKDDATA(int id) {
-  tree = std::make_shared<KD_TREE<pcl::PointXYZI>>();
+  tree = std::make_shared<KD_TREE<mins::PointXYZI>>();
   this->id = id;
 }

--- a/mins/src/update/lidar/LidarTypes.h
+++ b/mins/src/update/lidar/LidarTypes.h
@@ -25,17 +25,13 @@
 #include <memory>
 
 using namespace Eigen;
-namespace pcl {
-class PointXYZ;
-class PointXYZI;
-template <class pointT> class PointCloud;
-} // namespace pcl
-typedef std::shared_ptr<pcl::PointCloud<pcl::PointXYZI>> POINTCLOUD_XYZI_PTR;
+#include "update/lidar/PointCloud.h"
+typedef std::shared_ptr<mins::PointCloud<mins::PointXYZI>> POINTCLOUD_XYZI_PTR;
 template <class pointT> class KD_TREE;
 
 namespace mins {
 struct LiDARData {
-  LiDARData(double time, double ref_time, int id, std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> pointcloud, double max_range, double min_range);
+  LiDARData(double time, double ref_time, int id, std::shared_ptr<mins::PointCloud<mins::PointXYZ>> pointcloud, double max_range, double min_range);
 
   LiDARData();
 
@@ -71,7 +67,7 @@ struct LiDARData {
 struct iKDDATA {
   iKDDATA(int id);
   // ikd tree
-  std::shared_ptr<KD_TREE<pcl::PointXYZI>> tree;
+  std::shared_ptr<KD_TREE<mins::PointXYZI>> tree;
   // time this tree (map) is anchored at
   double time;
   // ID of corresponding LiDAR

--- a/mins/src/update/lidar/PointCloud.h
+++ b/mins/src/update/lidar/PointCloud.h
@@ -1,0 +1,158 @@
+/*
+ * Minimal in-house replacement for the small slice of PCL that MINS used:
+ * two point types, a vector-backed cloud, a rigid transform, and a centroid
+ * voxel-grid downsample. This drops PCL (and its boost/flann/vtk transitive
+ * weight) from every build - ROS1, ROS2, and the ROS-free CLI.
+ */
+#ifndef MINS_LIDAR_POINTCLOUD_H
+#define MINS_LIDAR_POINTCLOUD_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace mins {
+
+struct PointXYZ {
+  float x = 0.0f, y = 0.0f, z = 0.0f;
+  PointXYZ() = default;
+  PointXYZ(float px, float py, float pz) : x(px), y(py), z(pz) {}
+  Eigen::Vector3f getVector3fMap() const { return Eigen::Vector3f(x, y, z); }
+};
+
+struct PointXYZI {
+  float x = 0.0f, y = 0.0f, z = 0.0f, intensity = 0.0f;
+  PointXYZI() = default;
+  PointXYZI(float px, float py, float pz, float pi = 0.0f) : x(px), y(py), z(pz), intensity(pi) {}
+  Eigen::Vector3f getVector3fMap() const { return Eigen::Vector3f(x, y, z); }
+};
+
+// Cloud metadata. MINS stashes the lidar id in frame_id and the timestamp in stamp,
+// same as it did with pcl::PointCloud::header.
+struct CloudHeader {
+  std::uint64_t stamp = 0;
+  std::string frame_id;
+};
+
+// std::vector-backed cloud exposing only the members MINS actually used from pcl::PointCloud.
+template <class PointT> struct PointCloud {
+  using VectorType = std::vector<PointT, Eigen::aligned_allocator<PointT>>;
+  VectorType points;
+  CloudHeader header;
+  std::uint32_t width = 0, height = 1;
+  bool is_dense = false;
+
+  std::size_t size() const { return points.size(); }
+  bool empty() const { return points.empty(); }
+  void clear() { points.clear(); width = 0; }
+  void reserve(std::size_t n) { points.reserve(n); }
+  void resize(std::size_t n) {
+    points.resize(n);
+    width = static_cast<std::uint32_t>(n);
+    height = 1;
+  }
+  void push_back(const PointT &p) {
+    points.push_back(p);
+    width = static_cast<std::uint32_t>(points.size());
+    height = 1;
+  }
+  PointT &at(std::size_t i) { return points.at(i); }
+  const PointT &at(std::size_t i) const { return points.at(i); }
+  PointT &back() { return points.back(); }
+  const PointT &back() const { return points.back(); }
+  PointT &operator[](std::size_t i) { return points[i]; }
+  const PointT &operator[](std::size_t i) const { return points[i]; }
+  typename VectorType::iterator begin() { return points.begin(); }
+  typename VectorType::iterator end() { return points.end(); }
+  typename VectorType::const_iterator begin() const { return points.begin(); }
+  typename VectorType::const_iterator end() const { return points.end(); }
+  std::shared_ptr<PointCloud<PointT>> makeShared() const { return std::make_shared<PointCloud<PointT>>(*this); }
+};
+
+// out = T * in for the xyz of each point; other fields copied through.
+// Aliasing-safe: &in may equal &out (LidarHelper does an in-place transform).
+template <class PointT, class Derived>
+void transformPointCloud(const PointCloud<PointT> &in, PointCloud<PointT> &out, const Eigen::MatrixBase<Derived> &T) {
+  const Eigen::Matrix3f R = T.template block<3, 3>(0, 0).template cast<float>();
+  const Eigen::Vector3f t = T.template block<3, 1>(0, 3).template cast<float>();
+  typename PointCloud<PointT>::VectorType res(in.points.size());
+  for (std::size_t i = 0; i < in.points.size(); i++) {
+    PointT p = in.points[i];
+    const Eigen::Vector3f q = R * Eigen::Vector3f(p.x, p.y, p.z) + t;
+    p.x = q.x();
+    p.y = q.y();
+    p.z = q.z();
+    res[i] = p;
+  }
+  out.points = std::move(res);
+  out.width = static_cast<std::uint32_t>(out.points.size());
+  out.height = 1;
+}
+
+// Transform a single point by an affine (rotation + translation). Found via ADL on the point
+// type, the way pcl::transformPoint was. Mirrors LidarHelper's per-point transform.
+template <class PointT> PointT transformPoint(const PointT &in, const Eigen::Affine3f &T) {
+  PointT out = in;
+  const Eigen::Vector3f q = T * Eigen::Vector3f(in.x, in.y, in.z);
+  out.x = q.x();
+  out.y = q.y();
+  out.z = q.z();
+  return out;
+}
+
+// --- centroid voxel-grid downsample (matches pcl::VoxelGrid: one point per occupied voxel = mean) ---
+inline void voxel_add(Eigen::Vector4f &s, const PointXYZ &p) { s += Eigen::Vector4f(p.x, p.y, p.z, 0.0f); }
+inline void voxel_add(Eigen::Vector4f &s, const PointXYZI &p) { s += Eigen::Vector4f(p.x, p.y, p.z, p.intensity); }
+inline PointXYZ voxel_mean(const PointXYZ &, const Eigen::Vector4f &m) { return PointXYZ(m.x(), m.y(), m.z()); }
+inline PointXYZI voxel_mean(const PointXYZI &, const Eigen::Vector4f &m) { return PointXYZI(m.x(), m.y(), m.z(), m.w()); }
+
+template <class PointT> void voxel_downsample(const PointCloud<PointT> &in, PointCloud<PointT> &out, float leaf) {
+  if (leaf <= 0.0f || in.points.empty()) {
+    if (&out != &in)
+      out = in;
+    return;
+  }
+  // index origin at the cloud min corner, as pcl does, so voxel boundaries line up
+  Eigen::Vector3f mn(INFINITY, INFINITY, INFINITY);
+  for (const auto &p : in.points)
+    mn = mn.cwiseMin(Eigen::Vector3f(p.x, p.y, p.z));
+  const float inv = 1.0f / leaf;
+  struct Acc {
+    Eigen::Vector4f sum = Eigen::Vector4f::Zero();
+    int n = 0;
+  };
+  // Accumulate in a hash map (O(n)), then sort the (few) occupied voxels by key so the
+  // output order is deterministic - important because it feeds the ikd-Tree insertion order.
+  std::unordered_map<std::int64_t, Acc> voxels;
+  voxels.reserve(in.points.size());
+  for (const auto &p : in.points) {
+    auto ijk = [&](float c, float m) { return static_cast<std::int64_t>(std::floor((c - m) * inv)); };
+    std::int64_t i = ijk(p.x, mn.x()), j = ijk(p.y, mn.y()), k = ijk(p.z, mn.z());
+    std::int64_t key = (i & 0x1FFFFF) | ((j & 0x1FFFFF) << 21) | ((k & 0x1FFFFF) << 42);
+    Acc &a = voxels[key];
+    voxel_add(a.sum, p);
+    a.n++;
+  }
+  std::vector<const std::pair<const std::int64_t, Acc> *> items;
+  items.reserve(voxels.size());
+  for (const auto &kv : voxels)
+    items.push_back(&kv);
+  std::sort(items.begin(), items.end(), [](auto *a, auto *b) { return a->first < b->first; });
+  out.points.clear();
+  out.points.reserve(items.size());
+  for (const auto *kv : items)
+    out.points.push_back(voxel_mean(PointT(), kv->second.sum / static_cast<float>(kv->second.n)));
+  out.width = static_cast<std::uint32_t>(out.points.size());
+  out.height = 1;
+}
+
+} // namespace mins
+
+#endif // MINS_LIDAR_POINTCLOUD_H

--- a/mins/src/update/lidar/PointCloud2Convert.h
+++ b/mins/src/update/lidar/PointCloud2Convert.h
@@ -1,0 +1,95 @@
+/*
+ * Direct conversion between our mins::PointCloud and sensor_msgs PointCloud2, with no PCL
+ * in between (saves a full cloud copy per lidar frame). The ROS1 and ROS2 PointCloud2 /
+ * PointField messages are field-for-field identical, so one set of templates serves both.
+ */
+#ifndef MINS_LIDAR_POINTCLOUD2CONVERT_H
+#define MINS_LIDAR_POINTCLOUD2CONVERT_H
+
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "update/lidar/PointCloud.h"
+
+namespace mins {
+
+// PointField.datatype for float32 (same value in ROS1 and ROS2).
+static constexpr std::uint8_t PC2_FLOAT32 = 7;
+
+// sensor_msgs PointCloud2 -> XYZ cloud. Reads x/y/z by field offset, so any point layout
+// (Velodyne/Ouster clouds with ring, time, ... extra fields) parses correctly. Assumes the
+// x/y/z fields are float32, which every lidar driver emits.
+template <class PC2> std::shared_ptr<PointCloud<PointXYZ>> fromPC2(const PC2 &msg) {
+  auto out = std::make_shared<PointCloud<PointXYZ>>();
+  int ox = -1, oy = -1, oz = -1;
+  for (const auto &f : msg.fields) {
+    if (f.name == "x")
+      ox = static_cast<int>(f.offset);
+    else if (f.name == "y")
+      oy = static_cast<int>(f.offset);
+    else if (f.name == "z")
+      oz = static_cast<int>(f.offset);
+  }
+  if (ox < 0 || oy < 0 || oz < 0)
+    return out;
+  const std::size_t n = static_cast<std::size_t>(msg.width) * msg.height;
+  out->points.reserve(n);
+  for (std::size_t i = 0; i < n; i++) {
+    const unsigned char *b = &msg.data[i * msg.point_step];
+    float x, y, z;
+    std::memcpy(&x, b + ox, 4);
+    std::memcpy(&y, b + oy, 4);
+    std::memcpy(&z, b + oz, 4);
+    out->push_back(PointXYZ(x, y, z));
+  }
+  return out;
+}
+
+namespace detail {
+template <class PC2> void pc2_set_field(PC2 &out, int k, const char *name, std::uint32_t offset) {
+  out.fields[k].name = name;
+  out.fields[k].offset = offset;
+  out.fields[k].datatype = PC2_FLOAT32;
+  out.fields[k].count = 1;
+}
+template <class PC2> void pc2_alloc(PC2 &out, std::uint32_t npoints, std::uint32_t nfields, std::uint32_t point_step) {
+  out.height = 1;
+  out.width = npoints;
+  out.is_bigendian = false;
+  out.is_dense = false;
+  out.point_step = point_step;
+  out.row_step = point_step * npoints;
+  out.fields.resize(nfields);
+  out.data.resize(static_cast<std::size_t>(out.row_step));
+}
+} // namespace detail
+
+// XYZ cloud -> PointCloud2 (3 float fields).
+template <class PC2> void toPC2(const PointCloud<PointXYZ> &in, PC2 &out) {
+  detail::pc2_alloc(out, static_cast<std::uint32_t>(in.points.size()), 3, 12);
+  detail::pc2_set_field(out, 0, "x", 0);
+  detail::pc2_set_field(out, 1, "y", 4);
+  detail::pc2_set_field(out, 2, "z", 8);
+  for (std::size_t i = 0; i < in.points.size(); i++) {
+    float v[3] = {in.points[i].x, in.points[i].y, in.points[i].z};
+    std::memcpy(&out.data[i * 12], v, 12);
+  }
+}
+
+// XYZI cloud -> PointCloud2 (4 float fields).
+template <class PC2> void toPC2(const PointCloud<PointXYZI> &in, PC2 &out) {
+  detail::pc2_alloc(out, static_cast<std::uint32_t>(in.points.size()), 4, 16);
+  detail::pc2_set_field(out, 0, "x", 0);
+  detail::pc2_set_field(out, 1, "y", 4);
+  detail::pc2_set_field(out, 2, "z", 8);
+  detail::pc2_set_field(out, 3, "intensity", 12);
+  for (std::size_t i = 0; i < in.points.size(); i++) {
+    float v[4] = {in.points[i].x, in.points[i].y, in.points[i].z, in.points[i].intensity};
+    std::memcpy(&out.data[i * 16], v, 16);
+  }
+}
+
+} // namespace mins
+
+#endif // MINS_LIDAR_POINTCLOUD2CONVERT_H

--- a/mins/src/update/lidar/UpdaterLidar.cpp
+++ b/mins/src/update/lidar/UpdaterLidar.cpp
@@ -24,7 +24,8 @@
 #include "ikd_Tree.h"
 #include "options/OptionsEstimator.h"
 #include "options/OptionsLidar.h"
-#include "pcl/point_cloud.h"
+#include <iostream>
+#include "update/lidar/PointCloud.h"
 #include "state/State.h"
 #include "state/StateHelper.h"
 #include "types/PoseJPL.h"
@@ -47,7 +48,7 @@ UpdaterLidar::UpdaterLidar(shared_ptr<State> state) : state(state) {
   }
 }
 
-void UpdaterLidar::feed_measurement(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar) {
+void UpdaterLidar::feed_measurement(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar) {
   // Record first ever measurement time to set up reference time (ref. LidarTypes.h)
   FT < 0 ? FT = (double)lidar->header.stamp / 1000 : double();
 
@@ -283,7 +284,7 @@ bool UpdaterLidar::update(std::shared_ptr<LiDARData> lidar, shared_ptr<iKDDATA> 
         Vector3d pfinM_fej = pLinM_fej + RLtoM_fej * pfinL;
 
         // Get neighbors of this point in the map.
-        POINTCLOUD_XYZI_PTR neighbors_inM(new pcl::PointCloud<pcl::PointXYZI>);
+        POINTCLOUD_XYZI_PTR neighbors_inM(new mins::PointCloud<mins::PointXYZI>);
         if (!LidarHelper::get_neighbors(lidar->pfinM(i), neighbors_inM, ikd->tree, state->op->lidar))
           continue;
 

--- a/mins/src/update/lidar/UpdaterLidar.h
+++ b/mins/src/update/lidar/UpdaterLidar.h
@@ -27,11 +27,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace pcl {
-class PointXYZ;
-class PointXYZI;
-template <class pointT> class PointCloud;
-} // namespace pcl
+#include "update/lidar/PointCloud.h"
 
 using namespace std;
 using namespace Eigen;
@@ -48,7 +44,7 @@ public:
   UpdaterLidar(shared_ptr<State> state);
 
   /// Get lidar measurement
-  void feed_measurement(std::shared_ptr<pcl::PointCloud<pcl::PointXYZ>> lidar);
+  void feed_measurement(std::shared_ptr<mins::PointCloud<mins::PointXYZ>> lidar);
 
   /// Try update with available measurements
   void try_update();

--- a/mins/src/update/lidar/ikd_Tree.cpp
+++ b/mins/src/update/lidar/ikd_Tree.cpp
@@ -1500,6 +1500,5 @@ template <typename T> bool MANUAL_Q<T>::empty() { return is_empty; }
 template <typename T> int MANUAL_Q<T>::size() { return counter; }
 
 template class KD_TREE<ikdTree_PointType>;
-template class KD_TREE<pcl::PointXYZ>;
-template class KD_TREE<pcl::PointXYZI>;
-template class KD_TREE<pcl::PointXYZINormal>;
+template class KD_TREE<mins::PointXYZ>;
+template class KD_TREE<mins::PointXYZI>;

--- a/mins/src/update/lidar/ikd_Tree.h
+++ b/mins/src/update/lidar/ikd_Tree.h
@@ -11,7 +11,7 @@
 #include <chrono>
 #include <math.h>
 #include <memory>
-#include <pcl/point_types.h>
+#include "update/lidar/PointCloud.h"
 #include <pthread.h>
 #include <queue>
 #include <stdio.h>


### PR DESCRIPTION
Removes PCL from MINS. We only used a thin slice of it (two point types, a
vector-backed cloud, a rigid transform, and a voxel-grid downsample), so this
replaces that with a header-only shim and converts ROS messages straight to/from
our own point type instead of routing every lidar frame through PCL.

## Why
PCL drags in boost/flann/vtk. Dropping it sheds that transitive weight from the
ROS1, ROS2, and ROS-free CLI builds, and removes the last blocker for native
Windows/Mac builds (PCL was the reason vcpkg was needed).

## What changed
- `PointCloud.h` - in-house point types, `std::vector`-backed cloud, aliasing-safe
  `transformPointCloud`, O(n) centroid voxel-grid downsample (matches pcl::VoxelGrid).
- `PointCloud2Convert.h` - direct `sensor_msgs::PointCloud2` <-> `mins::PointCloud`,
  layout-agnostic field-offset parse (works with Velodyne/Ouster extra fields),
  one set of templates serving both ROS1 and ROS2. No PCL copy per frame.
- `ikd_Tree` instantiated on our point types.
- ROS headers forward-declare the mins types; full definition only in the .cpp
  files that build/read clouds.

## Verified
- ROS1 (Noetic) builds clean, no boost/flann/vtk pulled in.
- ROS-free CLI: sim RMSE 0.259/0.143 vs baseline 0.255/0.142, runtime unchanged.
- Real data: ran the full sensor stack on KAIST urban39 (2x Velodyne). Both lidars
  parse via the new converter, residuals healthy (Chi 100%), trajectory tracks.
