### PR TITLE
add ubuntu 24.04/26.04 ci coverage

### DIFF
--- a/.github/workflows/build_ros2_jazzy.yml
+++ b/.github/workflows/build_ros2_jazzy.yml
@@ -1,0 +1,26 @@
+name: ROS2 Jazzy (Ubuntu 24.04)
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_jazzy:
+    name: "ROS2 Ubuntu 24.04"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Docker image (Jazzy 24.04)
+        run: docker build . --file Dockerfile_jazzy_24_04 --tag mins:jazzy
+      - name: Smoke test - simulation runs end to end
+        run: |
+          docker run --rm --entrypoint /bin/bash mins:jazzy -c '
+            set -eo pipefail
+            source /opt/ros/jazzy/setup.bash && source /work/install/setup.bash
+            cfg=/work/install/mins/share/mins/config/simulation/config.yaml
+            timeout 600 ros2 run mins simulation "$cfg" 2>&1 | tee /tmp/sim.log
+            grep -q "RMSE average" /tmp/sim.log
+          '

--- a/.github/workflows/build_ros2_lyrical.yml
+++ b/.github/workflows/build_ros2_lyrical.yml
@@ -1,0 +1,26 @@
+name: ROS2 Lyrical (Ubuntu 26.04)
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_lyrical:
+    name: "ROS2 Ubuntu 26.04"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Docker image (Lyrical 26.04)
+        run: docker build . --file Dockerfile_lyrical_26_04 --tag mins:lyrical
+      - name: Smoke test - simulation runs end to end
+        run: |
+          docker run --rm --entrypoint /bin/bash mins:lyrical -c '
+            set -eo pipefail
+            source /opt/ros/lyrical/setup.bash && source /work/install/setup.bash
+            cfg=/work/install/mins/share/mins/config/simulation/config.yaml
+            timeout 600 ros2 run mins simulation "$cfg" 2>&1 | tee /tmp/sim.log
+            grep -q "RMSE average" /tmp/sim.log
+          '

--- a/.github/workflows/build_rosfree_24_04.yml
+++ b/.github/workflows/build_rosfree_24_04.yml
@@ -1,0 +1,27 @@
+name: ROS-free (Ubuntu 24.04)
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_rosfree_linux_2404:
+    name: "No ROS - Ubuntu 24.04"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build core + headless CLI with no ROS
+        run: docker build . --file Dockerfile_rosfree_ubuntu_24_04 --tag mins:rosfree-2404
+      - name: Run headless CLI (no ROS) end to end
+        run: |
+          docker run --rm -e MINS_ROOT=/work/src/MINS mins:rosfree-2404 bash -c '
+            set -eo pipefail
+            mkdir -p /outputs/tmp/0
+            timeout 600 /work/build/mins/mins_cli /work/src/MINS/mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log
+            grep -q "RMSE average" /tmp/cli.log
+          '

--- a/.github/workflows/build_rosfree_26_04.yml
+++ b/.github/workflows/build_rosfree_26_04.yml
@@ -1,0 +1,27 @@
+name: ROS-free (Ubuntu 26.04)
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build_rosfree_linux_2604:
+    name: "No ROS - Ubuntu 26.04"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build core + headless CLI with no ROS
+        run: docker build . --file Dockerfile_rosfree_ubuntu_26_04 --tag mins:rosfree-2604
+      - name: Run headless CLI (no ROS) end to end
+        run: |
+          docker run --rm -e MINS_ROOT=/work/src/MINS mins:rosfree-2604 bash -c '
+            set -eo pipefail
+            mkdir -p /outputs/tmp/0
+            timeout 600 /work/build/mins/mins_cli /work/src/MINS/mins/config/simulation/config.yaml 2>&1 | tee /tmp/cli.log
+            grep -q "RMSE average" /tmp/cli.log
+          '

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,4 @@
-name: Windows Workflow
+name: Windows (x64)
 
 # Builds the MINS core library + headless CLI natively on Windows (MSVC, x64). No ROS, no
 # Docker. PCL is gone, and Eigen is header-only so it installs directly (no vcpkg, no

--- a/Dockerfile_jazzy_24_04
+++ b/Dockerfile_jazzy_24_04
@@ -1,0 +1,27 @@
+FROM ros:jazzy-perception-noble
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt apt-get update --fix-missing && apt-get upgrade -y
+
+RUN --mount=type=cache,target=/var/cache/apt\
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends --yes \
+  python3-colcon-common-extensions \
+  python3-rosdep
+
+WORKDIR /work
+
+RUN useradd -ms /bin/bash ros &&\
+  chown ros:ros /work &&\
+  usermod -aG sudo ros &&\
+  echo "ros ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers &&\
+  echo "ros:ros" | chpasswd
+
+USER ros
+
+COPY . /work/src/MINS
+
+RUN bash /work/src/MINS/build_ros2.sh
+
+RUN echo "source '/work/install/setup.bash'" >> ~/.bashrc
+

--- a/Dockerfile_lyrical_26_04
+++ b/Dockerfile_lyrical_26_04
@@ -1,0 +1,27 @@
+FROM ros:lyrical-perception-resolute
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt apt-get update --fix-missing && apt-get upgrade -y
+
+RUN --mount=type=cache,target=/var/cache/apt\
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends --yes \
+  python3-colcon-common-extensions \
+  python3-rosdep
+
+WORKDIR /work
+
+RUN useradd -ms /bin/bash ros &&\
+  chown ros:ros /work &&\
+  usermod -aG sudo ros &&\
+  echo "ros ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers &&\
+  echo "ros:ros" | chpasswd
+
+USER ros
+
+COPY . /work/src/MINS
+
+RUN bash /work/src/MINS/build_ros2.sh
+
+RUN echo "source '/work/install/setup.bash'" >> ~/.bashrc
+

--- a/Dockerfile_rosfree_ubuntu_24_04
+++ b/Dockerfile_rosfree_ubuntu_24_04
@@ -1,6 +1,6 @@
 # Builds the MINS core library + headless CLI with NO ROS at all, to prove the
 # core stays ROS-free. Plain cmake, only apt + bundled thirdparty deps.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/Dockerfile_rosfree_ubuntu_26_04
+++ b/Dockerfile_rosfree_ubuntu_26_04
@@ -1,6 +1,6 @@
 # Builds the MINS core library + headless CLI with NO ROS at all, to prove the
 # core stays ROS-free. Plain cmake, only apt + bundled thirdparty deps.
-FROM ubuntu:22.04
+FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,7 +2,11 @@
 [![ROS1 Melodic (Ubuntu 18.04)](https://github.com/rpng/MINS/actions/workflows/build_ros1_melodic.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1_melodic.yml)
 [![ROS1 Noetic (Ubuntu 20.04)](https://github.com/rpng/MINS/actions/workflows/build_ros1_noetic.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros1_noetic.yml)
 [![ROS2 Humble (Ubuntu 22.04)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2.yml)
+[![ROS2 Jazzy (Ubuntu 24.04)](https://github.com/rpng/MINS/actions/workflows/build_ros2_jazzy.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2_jazzy.yml)
+[![ROS2 Lyrical (Ubuntu 26.04)](https://github.com/rpng/MINS/actions/workflows/build_ros2_lyrical.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_ros2_lyrical.yml)
 [![ROS-free (Ubuntu 22.04)](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_rosfree.yml)
+[![ROS-free (Ubuntu 24.04)](https://github.com/rpng/MINS/actions/workflows/build_rosfree_24_04.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_rosfree_24_04.yml)
+[![ROS-free (Ubuntu 26.04)](https://github.com/rpng/MINS/actions/workflows/build_rosfree_26_04.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_rosfree_26_04.yml)
 [![macOS (arm64)](https://github.com/rpng/MINS/actions/workflows/build_macos.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_macos.yml)
 [![Windows (x64)](https://github.com/rpng/MINS/actions/workflows/build_windows.yml/badge.svg)](https://github.com/rpng/MINS/actions/workflows/build_windows.yml)
 

--- a/build_ros2.sh
+++ b/build_ros2.sh
@@ -5,7 +5,7 @@ set -e
 MINS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${MINS_DIR}/../.."
 
-source /opt/ros/humble/setup.bash
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
 colcon build --paths "${MINS_DIR}"/thirdparty/*
 source install/setup.bash
 colcon build --paths "${MINS_DIR}"/thirdparty/open_vins/*

--- a/mins/cmake/ROS2.cmake
+++ b/mins/cmake/ROS2.cmake
@@ -1,6 +1,30 @@
 cmake_minimum_required(VERSION 3.5.1)
 
 find_package(ament_cmake REQUIRED)
+
+# ament_target_dependencies() was dropped from ament_cmake_target_dependencies on newer
+# distros (e.g. ROS2 Lyrical) in favor of modern CMake imported targets. Shim it back in
+# when missing, falling back to classic ${dep}_INCLUDE_DIRS/_LIBRARIES if no modern target.
+if(NOT COMMAND ament_target_dependencies)
+  macro(ament_target_dependencies target)
+    foreach(_dep ${ARGN})
+      if(TARGET ${_dep}::${_dep})
+        target_link_libraries(${target} ${_dep}::${_dep})
+      else()
+        if(${_dep}_INCLUDE_DIRS)
+          target_include_directories(${target} PUBLIC ${${_dep}_INCLUDE_DIRS})
+        endif()
+        if(${_dep}_LIBRARIES)
+          target_link_libraries(${target} ${${_dep}_LIBRARIES})
+        endif()
+        if(${_dep}_DEFINITIONS)
+          target_compile_definitions(${target} PUBLIC ${${_dep}_DEFINITIONS})
+        endif()
+      endif()
+    endforeach()
+  endmacro()
+endif()
+
 find_package(rclcpp REQUIRED)
 find_package(rosbag2 REQUIRED COMPONENTS rmw_adapters message_filters rosbag2_storage_builtin)
 find_package(tf2_ros REQUIRED COMPONENTS tf2_cpp)  # Replaces tf
@@ -16,12 +40,13 @@ find_package(image_geometry REQUIRED)  # Might require additional setup
 find_package(visualization_msgs REQUIRED)
 find_package(image_transport REQUIRED)  # Might require additional setup
 find_package(cv_bridge REQUIRED)        # Might require additional setup
+find_package(ament_index_cpp REQUIRED)  # get_package_share_directory()
 
 # Other dependencies (if available through ROS 2 packages)
 find_package(ov_core REQUIRED)   # Might not be available as a ROS 2 package
 
 add_definitions(-DROS_AVAILABLE=2)
-ament_export_dependencies(rclcpp rosbag2 tf2_ros std_msgs geometry_msgs sensor_msgs nav_msgs std_srvs image_geometry visualization_msgs image_transport cv_bridge ov_core)
+ament_export_dependencies(rclcpp rosbag2 tf2_ros std_msgs geometry_msgs sensor_msgs nav_msgs std_srvs image_geometry visualization_msgs image_transport cv_bridge ament_index_cpp ov_core)
 # ament_export_include_directories(src/)
 ament_export_libraries(mins_lib)
 
@@ -37,6 +62,7 @@ list(APPEND ament_libraries
         nav_msgs
         cv_bridge
         image_transport
+        ament_index_cpp
         ov_core
         image_geometry
 )

--- a/mins/src/core/ROS2Helper.cpp
+++ b/mins/src/core/ROS2Helper.cpp
@@ -39,7 +39,11 @@
 #include "update/vicon/ViconTypes.h"
 #include "update/wheel/WheelTypes.h"
 #include "utils/Print_Logger.h"
+#if __has_include(<cv_bridge/cv_bridge.h>)
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <vector>
 
 using namespace sensor_msgs::msg;
@@ -249,7 +253,9 @@ bool ROS2Helper::Image2Data(const sensor_msgs::msg::CompressedImage::ConstShared
   // Create the measurement
   cam.timestamp = rclcpp::Time(msg->header.stamp).seconds();
   cam.sensor_ids.push_back(cam_id);
-  cam.images.push_back(cv::imdecode(cv::Mat(msg->data), 0));
+  // Build via pointer+size instead of the std::vector<> ctor: rosidl's rebound allocator
+  // type doesn't always match cv::Mat's std::vector<_Tp> template deduction on newer distros.
+  cam.images.push_back(cv::imdecode(cv::Mat(1, (int)msg->data.size(), CV_8UC1, (void *)msg->data.data()), 0));
 
   // Load the mask if we are using it, else it is empty
   // TODO: in the future we should get this from external pixel segmentation

--- a/mins/src/core/ROS2Helper.h
+++ b/mins/src/core/ROS2Helper.h
@@ -46,7 +46,6 @@ template <class PointT> struct PointCloud;
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2/transform_datatypes.h>
 
 using namespace std;
 using namespace sensor_msgs;

--- a/mins/src/core/ROS2Publisher.cpp
+++ b/mins/src/core/ROS2Publisher.cpp
@@ -56,7 +56,11 @@
 #include "update/lidar/ikd_Tree.h"
 #include "update/vicon/ViconTypes.h"
 #include "utils/Print_Logger.h"
+#if __has_include(<cv_bridge/cv_bridge.h>)
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <image_transport/image_transport.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 

--- a/mins/src/core/ROS2Subscriber.cpp
+++ b/mins/src/core/ROS2Subscriber.cpp
@@ -66,8 +66,8 @@ ROS2Subscriber::ROS2Subscriber(std::shared_ptr<rclcpp::Node> node, std::shared_p
           int cam_id1 = op->cam->stereo_pairs.at(i);
           // Create sync filter (they have unique pointers internally, so we have to use move logic here...)
           if (op->cam->compressed.at(cam_id0)) {
-            auto image_sub0 = std::make_shared<message_filters::Subscriber<CompressedImage>>(node, op->cam->topic.at(cam_id0));
-            auto image_sub1 = std::make_shared<message_filters::Subscriber<CompressedImage>>(node, op->cam->topic.at(cam_id1));
+            auto image_sub0 = make_mf_subscriber<CompressedImage>(node, op->cam->topic.at(cam_id0));
+            auto image_sub1 = make_mf_subscriber<CompressedImage>(node, op->cam->topic.at(cam_id1));
             auto sync = std::make_shared<message_filters::Synchronizer<csync_pol>>(csync_pol(10), *image_sub0, *image_sub1);
             sync->registerCallback(std::bind(&ROS2Subscriber::callback_stereo_C, this, std::placeholders::_1, std::placeholders::_2, cam_id0, cam_id1));
             // Append to our vector of subscribers
@@ -78,8 +78,8 @@ ROS2Subscriber::ROS2Subscriber(std::shared_ptr<rclcpp::Node> node, std::shared_p
             PRINT2("subscribing to cam (stereo, compressed): %s\n", op->cam->topic.at(cam_id1).c_str());
 
           } else {
-            auto image_sub0 = std::make_shared<message_filters::Subscriber<Image>>(node, op->cam->topic.at(cam_id0));
-            auto image_sub1 = std::make_shared<message_filters::Subscriber<Image>>(node, op->cam->topic.at(cam_id1));
+            auto image_sub0 = make_mf_subscriber<Image>(node, op->cam->topic.at(cam_id0));
+            auto image_sub1 = make_mf_subscriber<Image>(node, op->cam->topic.at(cam_id1));
             auto sync = std::make_shared<message_filters::Synchronizer<sync_pol>>(sync_pol(10), *image_sub0, *image_sub1);
             sync->registerCallback(std::bind(&ROS2Subscriber::callback_stereo_I, this, std::placeholders::_1, std::placeholders::_2, cam_id0, cam_id1));
             // Append to our vector of subscribers
@@ -93,12 +93,12 @@ ROS2Subscriber::ROS2Subscriber(std::shared_ptr<rclcpp::Node> node, std::shared_p
       } else {
         // create MONO subscriber
         if (op->cam->compressed.at(i)) {
-          auto image_sub = std::make_shared<message_filters::Subscriber<CompressedImage>>(node, op->cam->topic.at(i));
+          auto image_sub = make_mf_subscriber<CompressedImage>(node, op->cam->topic.at(i));
           image_sub->registerCallback(std::bind(&ROS2Subscriber::callback_monocular_C, this, std::placeholders::_1, i));
           cimage_subs.push_back(image_sub);
           PRINT2("subscribing to cam (mono, compressed): %s\n", op->cam->topic.at(i).c_str());
         } else {
-          auto image_sub = std::make_shared<message_filters::Subscriber<Image>>(node, op->cam->topic.at(i));
+          auto image_sub = make_mf_subscriber<Image>(node, op->cam->topic.at(i));
           image_sub->registerCallback(std::bind(&ROS2Subscriber::callback_monocular_I, this, std::placeholders::_1, i));
           image_subs.push_back(image_sub);
           PRINT2("subscribing to cam (mono): %s\n", op->cam->topic.at(i).c_str());

--- a/mins/src/core/ROS2Subscriber.h
+++ b/mins/src/core/ROS2Subscriber.h
@@ -39,14 +39,31 @@
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "std_srvs/srv/empty.hpp"
+#if __has_include(<message_filters/subscriber.h>)
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/time_synchronizer.h>
+#else
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/time_synchronizer.hpp>
+#endif
 
 using namespace std;
 using namespace sensor_msgs::msg;
 using namespace nav_msgs::msg;
 namespace mins {
+
+// message_filters::Subscriber dropped its default-QoS 2-arg constructor on newer distros
+// (e.g. ROS2 Lyrical) in favor of a required rclcpp::QoS third argument; older distros take
+// a rmw_qos_profile_t there instead, so this can't be a single unconditional call.
+template <typename M> std::shared_ptr<message_filters::Subscriber<M>> make_mf_subscriber(std::shared_ptr<rclcpp::Node> node, const std::string &topic) {
+#if __has_include(<message_filters/subscriber.h>)
+  return std::make_shared<message_filters::Subscriber<M>>(node, topic);
+#else
+  return std::make_shared<message_filters::Subscriber<M>>(node, topic, rclcpp::QoS(10));
+#endif
+}
 
 class SystemManager;
 struct OptionsEstimator;

--- a/mins/src/utils/Print_Logger.h
+++ b/mins/src/utils/Print_Logger.h
@@ -28,6 +28,7 @@
 #ifndef MINS_CORE_PRINT_H
 #define MINS_CORE_PRINT_H
 
+#include <cstdint>
 #include <string>
 
 namespace mins {

--- a/mins_eval/CMakeLists.txt
+++ b/mins_eval/CMakeLists.txt
@@ -35,7 +35,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-sign
 # Enable debug flags (use if you want to debug in gdb)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized")
 
-find_package(PCL REQUIRED QUIET)
 # Find ROS build system
 
 # GCC older than 9.1 needs an explicit lib for std::filesystem (ROS Melodic ships GCC 7.5)

--- a/mins_eval/cmake/ROS1.cmake
+++ b/mins_eval/cmake/ROS1.cmake
@@ -12,7 +12,6 @@ catkin_package(
 include_directories(
         src
         ${EIGEN3_INCLUDE_DIR}
-        ${PCL_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}
 )

--- a/mins_eval/cmake/ROS2.cmake
+++ b/mins_eval/cmake/ROS2.cmake
@@ -2,6 +2,29 @@ cmake_minimum_required(VERSION 3.5.1)
 
 find_package(ament_cmake REQUIRED)
 
+# ament_target_dependencies() was dropped from ament_cmake_target_dependencies on newer
+# distros (e.g. ROS2 Lyrical) in favor of modern CMake imported targets. Shim it back in
+# when missing, falling back to classic ${dep}_INCLUDE_DIRS/_LIBRARIES if no modern target.
+if(NOT COMMAND ament_target_dependencies)
+  macro(ament_target_dependencies target)
+    foreach(_dep ${ARGN})
+      if(TARGET ${_dep}::${_dep})
+        target_link_libraries(${target} ${_dep}::${_dep})
+      else()
+        if(${_dep}_INCLUDE_DIRS)
+          target_include_directories(${target} PUBLIC ${${_dep}_INCLUDE_DIRS})
+        endif()
+        if(${_dep}_LIBRARIES)
+          target_link_libraries(${target} ${${_dep}_LIBRARIES})
+        endif()
+        if(${_dep}_DEFINITIONS)
+          target_compile_definitions(${target} PUBLIC ${${_dep}_DEFINITIONS})
+        endif()
+      endif()
+    endforeach()
+  endmacro()
+endif()
+
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
 find_package(nav_msgs REQUIRED)

--- a/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_core/cmake/ROS2.cmake
@@ -2,6 +2,30 @@ cmake_minimum_required(VERSION 3.5.1)
 
 # Find ros dependencies
 find_package(ament_cmake REQUIRED)
+
+# ament_target_dependencies() was dropped from ament_cmake_target_dependencies on newer
+# distros (e.g. ROS2 Lyrical) in favor of modern CMake imported targets. Shim it back in
+# when missing, falling back to classic ${dep}_INCLUDE_DIRS/_LIBRARIES if no modern target.
+if(NOT COMMAND ament_target_dependencies)
+  macro(ament_target_dependencies target)
+    foreach(_dep ${ARGN})
+      if(TARGET ${_dep}::${_dep})
+        target_link_libraries(${target} ${_dep}::${_dep})
+      else()
+        if(${_dep}_INCLUDE_DIRS)
+          target_include_directories(${target} PUBLIC ${${_dep}_INCLUDE_DIRS})
+        endif()
+        if(${_dep}_LIBRARIES)
+          target_link_libraries(${target} ${${_dep}_LIBRARIES})
+        endif()
+        if(${_dep}_DEFINITIONS)
+          target_compile_definitions(${target} PUBLIC ${${_dep}_DEFINITIONS})
+        endif()
+      endif()
+    endforeach()
+  endmacro()
+endif()
+
 find_package(rclcpp REQUIRED)
 find_package(cv_bridge REQUIRED)
 

--- a/thirdparty/open_vins/ov_core/src/track/TrackAruco.cpp
+++ b/thirdparty/open_vins/ov_core/src/track/TrackAruco.cpp
@@ -96,7 +96,11 @@ void TrackAruco::perform_tracking(double timestamp, const cv::Mat &imgin, size_t
   //===================================================================================
 
   // Perform extraction
+#if (CV_VERSION_MAJOR * 100 + CV_VERSION_MINOR) >= 407
+  aruco_detector.detectMarkers(img0, corners[cam_id], ids_aruco[cam_id], rejects[cam_id]);
+#else
   cv::aruco::detectMarkers(img0, aruco_dict, corners[cam_id], ids_aruco[cam_id], aruco_params, rejects[cam_id]);
+#endif
   rT2 = std::chrono::steady_clock::now();
 
   //===================================================================================

--- a/thirdparty/open_vins/ov_core/src/track/TrackAruco.h
+++ b/thirdparty/open_vins/ov_core/src/track/TrackAruco.h
@@ -55,10 +55,17 @@ public:
                       bool downsize)
       : TrackBase(cameras, 0, numaruco, stereo, histmethod), max_tag_id(numaruco), do_downsizing(downsize) {
 #if ENABLE_ARUCO_TAGS
+#if (CV_VERSION_MAJOR * 100 + CV_VERSION_MINOR) >= 407
+    // OpenCV >= 4.7 dropped the Ptr-based factory API in favor of value types + ArucoDetector
+    aruco_dict = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
+    aruco_params = cv::aruco::DetectorParameters();
+    aruco_detector = cv::aruco::ArucoDetector(aruco_dict, aruco_params);
+#else
     aruco_dict = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
     aruco_params = cv::aruco::DetectorParameters::create();
     // NOTE: people with newer opencv might fail here
     // aruco_params->cornerRefinementMethod = cv::aruco::CornerRefineMethod::CORNER_REFINE_SUBPIX;
+#endif
 #else
     PRINT_ERROR(RED "[ERROR]: you have not compiled with aruco tag support!!!\n" RESET);
     std::exit(EXIT_FAILURE);
@@ -101,11 +108,18 @@ protected:
   bool do_downsizing;
 
 #if ENABLE_ARUCO_TAGS
+#if (CV_VERSION_MAJOR * 100 + CV_VERSION_MINOR) >= 407
+  // Our dictionary and parameters that we will extract aruco tags with
+  cv::aruco::Dictionary aruco_dict;
+  cv::aruco::DetectorParameters aruco_params;
+  cv::aruco::ArucoDetector aruco_detector;
+#else
   // Our dictionary that we will extract aruco tags with
   cv::Ptr<cv::aruco::Dictionary> aruco_dict;
 
   // Parameters the opencv extractor uses
   cv::Ptr<cv::aruco::DetectorParameters> aruco_params;
+#endif
 
   // Our tag IDs and corner we will get from the extractor
   std::unordered_map<size_t, std::vector<int>> ids_aruco;

--- a/thirdparty/open_vins/ov_eval/CMakeLists.txt
+++ b/thirdparty/open_vins/ov_eval/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ov_eval)
 
 # Include libraries
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system filesystem thread date_time)
+find_package(Boost REQUIRED COMPONENTS filesystem thread date_time) # system was dropped as a compiled component in Boost >= 1.87, and unused directly here
 
 # check if we have our python libs files (will search for python3 then python2 installs)
 # sudo apt-get install python-matplotlib python-numpy python-dev

--- a/thirdparty/open_vins/ov_eval/cmake/ROS2.cmake
+++ b/thirdparty/open_vins/ov_eval/cmake/ROS2.cmake
@@ -2,6 +2,30 @@ cmake_minimum_required(VERSION 3.5.1)
 
 # Find ROS build system
 find_package(ament_cmake REQUIRED)
+
+# ament_target_dependencies() was dropped from ament_cmake_target_dependencies on newer
+# distros (e.g. ROS2 Lyrical) in favor of modern CMake imported targets. Shim it back in
+# when missing, falling back to classic ${dep}_INCLUDE_DIRS/_LIBRARIES if no modern target.
+if(NOT COMMAND ament_target_dependencies)
+  macro(ament_target_dependencies target)
+    foreach(_dep ${ARGN})
+      if(TARGET ${_dep}::${_dep})
+        target_link_libraries(${target} ${_dep}::${_dep})
+      else()
+        if(${_dep}_INCLUDE_DIRS)
+          target_include_directories(${target} PUBLIC ${${_dep}_INCLUDE_DIRS})
+        endif()
+        if(${_dep}_LIBRARIES)
+          target_link_libraries(${target} ${${_dep}_LIBRARIES})
+        endif()
+        if(${_dep}_DEFINITIONS)
+          target_compile_definitions(${target} PUBLIC ${${_dep}_DEFINITIONS})
+        endif()
+      endif()
+    endforeach()
+  endmacro()
+endif()
+
 find_package(rclcpp REQUIRED)
 find_package(ov_core REQUIRED)
 


### PR DESCRIPTION
adds ros2 jazzy (24.04) and lyrical (26.04) docker builds + smoke tests, same for rosfree. also drops pcl and yaml-cpp from the rosfree 22.04 image, both dead deps (mins reads yaml via opencv FileStorage, never used pcl types).