### PR TITLE
unit tests: vicon Jacobian numerical verification

### DIFF
--- a/.github/scripts/gen_unit_test_summary.py
+++ b/.github/scripts/gen_unit_test_summary.py
@@ -1,0 +1,24 @@
+import re, os, sys
+
+text = open(sys.argv[1]).read() if len(sys.argv) > 1 and os.path.exists(sys.argv[1]) else ''
+tests = re.findall(r'\d+/\d+ Test #\d+: (\S+)[\s.]+(\w+)\s+([\d.]+) sec', text)
+total_line = re.search(r'(\d+)% tests passed, (\d+) tests failed out of (\d+)', text)
+
+lines = ['## Unit Test Results', '', '| Test | Result | Duration |', '|------|--------|----------|']
+for name, status, duration in tests:
+    icon = '✅' if status == 'Passed' else '❌'
+    lines.append(f'| `{name}` | {icon} {status} | {duration}s |')
+lines.append('')
+if total_line:
+    _, failed, total = total_line.groups()
+    passed = int(total) - int(failed)
+    lines.append(f'**{passed}/{total} passed**')
+elif not tests:
+    lines.append('*No test results found (build may have failed)*')
+
+summary = '\n'.join(lines)
+print(summary)
+gss = os.environ.get('GITHUB_STEP_SUMMARY')
+if gss:
+    with open(gss, 'a') as f:
+        f.write(summary + '\n')

--- a/.github/scripts/gen_unit_test_summary.py
+++ b/.github/scripts/gen_unit_test_summary.py
@@ -1,10 +1,12 @@
 import re, os, sys
 
 text = open(sys.argv[1]).read() if len(sys.argv) > 1 and os.path.exists(sys.argv[1]) else ''
+out_file = sys.argv[2] if len(sys.argv) > 2 else None
+
 tests = re.findall(r'\d+/\d+ Test #\d+: (\S+)[\s.]+(\w+)\s+([\d.]+) sec', text)
 total_line = re.search(r'(\d+)% tests passed, (\d+) tests failed out of (\d+)', text)
 
-lines = ['## Unit Test Results', '', '| Test | Result | Duration |', '|------|--------|----------|']
+lines = ['<!-- mins-unit-test-report -->', '## Unit Test Results', '', '| Test | Result | Duration |', '|------|--------|----------|']
 for name, status, duration in tests:
     icon = '✅' if status == 'Passed' else '❌'
     lines.append(f'| `{name}` | {icon} {status} | {duration}s |')
@@ -18,7 +20,11 @@ elif not tests:
 
 summary = '\n'.join(lines)
 print(summary)
+
 gss = os.environ.get('GITHUB_STEP_SUMMARY')
 if gss:
     with open(gss, 'a') as f:
+        f.write(summary + '\n')
+if out_file:
+    with open(out_file, 'w') as f:
         f.write(summary + '\n')

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -19,12 +19,19 @@ jobs:
         run: docker run --rm --entrypoint /bin/bash mins:noetic -c "source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash && export OMP_NUM_THREADS=1 && roslaunch mins simulation.launch sys_verbosity:=3"
       - name: Run unit tests
         run: |
-          docker run --rm --entrypoint /bin/bash mins:noetic -c "
+          mkdir -p /tmp/mins_tests
+          docker run --rm -v /tmp/mins_tests:/results --entrypoint /bin/bash mins:noetic -c '
             set -eo pipefail
             apt-get update -q && apt-get install -qy --no-install-recommends libgtest-dev
             source /opt/ros/noetic/setup.bash
             cd /catkin_ws
             catkin config --cmake-args -DBUILD_TESTS=ON
             catkin build mins
-            cd /catkin_ws/build/mins && ctest --output-on-failure
-          "
+            cd /catkin_ws/build/mins
+            set +e
+            ctest --output-on-failure > /results/ctest.txt 2>&1
+            echo $? > /results/exit.txt
+            cat /results/ctest.txt
+          '
+          python3 .github/scripts/gen_unit_test_summary.py /tmp/mins_tests/ctest.txt || true
+          exit $(cat /tmp/mins_tests/exit.txt 2>/dev/null || echo 1)

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
 
   build_2004:
@@ -33,5 +37,31 @@ jobs:
             echo $? > /results/exit.txt
             cat /results/ctest.txt
           '
-          python3 .github/scripts/gen_unit_test_summary.py /tmp/mins_tests/ctest.txt || true
+          python3 .github/scripts/gen_unit_test_summary.py /tmp/mins_tests/ctest.txt unit_test_report.md || true
           exit $(cat /tmp/mins_tests/exit.txt 2>/dev/null || echo 1)
+      - name: Post unit test report to PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.existsSync('unit_test_report.md')
+              ? fs.readFileSync('unit_test_report.md', 'utf8')
+              : '<!-- mins-unit-test-report -->\n## Unit Test Results\n\n*Report not generated — check the CI log.*';
+            const marker = '<!-- mins-unit-test-report -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body,
+              });
+            }

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -17,3 +17,14 @@ jobs:
         run: docker build . --file Dockerfile_noetic_20_04 --tag mins:noetic
       - name: Run MINS simulation (smoke test)
         run: docker run --rm --entrypoint /bin/bash mins:noetic -c "source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash && export OMP_NUM_THREADS=1 && roslaunch mins simulation.launch sys_verbosity:=3"
+      - name: Run unit tests
+        run: |
+          docker run --rm --entrypoint /bin/bash mins:noetic -c "
+            set -eo pipefail
+            apt-get update -q && apt-get install -qy --no-install-recommends libgtest-dev
+            source /opt/ros/noetic/setup.bash
+            cd /catkin_ws
+            catkin config --cmake-args -DBUILD_TESTS=ON
+            catkin build mins
+            cd /catkin_ws/build/mins && ctest --output-on-failure
+          "

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -105,16 +105,16 @@ jobs:
       - name: Run ${{ env.SEEDS }} simulations per algorithm
         run: |
           set -e
-          last=$((SEEDS-1))
+          last_seed=$((SEEDS-1))
           for ref in master pr; do
             mkdir -p out_$ref
             docker run --rm --entrypoint /bin/bash -v "$PWD/out_$ref:/outputs" "mins:$ref" -c '
               source /opt/ros/noetic/setup.bash && source /catkin_ws/devel/setup.bash
               export OMP_NUM_THREADS=1
-              for s in $(seq 0 '"$last"'); do
-                rm -f /outputs/tmp/$s.txt /outputs/tmp/$s.time
-                sed -i "s/^  seed: .*/  seed: $s/" /catkin_ws/src/MINS/mins/config/simulation/config_simulation.yaml
-                roslaunch mins simulation.launch sim_seed:=$s sys_verbosity:=3 \
+              for seed in $(seq 0 '"$last_seed"'); do
+                rm -f /outputs/tmp/$seed.txt /outputs/tmp/$seed.time
+                sed -i "s/^  seed: .*/  seed: $seed/" /catkin_ws/src/MINS/mins/config/simulation/config_simulation.yaml
+                roslaunch mins simulation.launch sim_seed:=$seed sys_verbosity:=3 \
                   sys_save_state:=false '"${{ matrix.args }}"'
               done'
           done

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -77,6 +77,9 @@ jobs:
           - config: stereo_gps
             gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=true wheel_enabled:=false vicon_enabled:=false"
+          - config: stereo_vicon
+            gt: holonomic
+            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=false vicon_enabled:=true"
           - config: stereo_wheel
             gt: nonholonomic_planar
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=true vicon_enabled:=false sim_const_planar:=true"

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -113,6 +113,7 @@ jobs:
               export OMP_NUM_THREADS=1
               for s in $(seq 0 '"$last"'); do
                 rm -f /outputs/tmp/$s.txt /outputs/tmp/$s.time
+                sed -i "s/^  seed: .*/  seed: $s/" /catkin_ws/src/MINS/mins/config/simulation/config_simulation.yaml
                 roslaunch mins simulation.launch sim_seed:=$s sys_verbosity:=3 \
                   sys_save_state:=false '"${{ matrix.args }}"'
               done'

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -77,9 +77,9 @@ jobs:
           - config: stereo_gps
             gt: holonomic
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=true wheel_enabled:=false vicon_enabled:=false"
-          - config: stereo_vicon
+          - config: vicon
             gt: holonomic
-            args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=false vicon_enabled:=true"
+            args: "cam_enabled:=false lidar_enabled:=false gps_enabled:=false wheel_enabled:=false vicon_enabled:=true"
           - config: stereo_wheel
             gt: nonholonomic_planar
             args: "cam_enabled:=true cam_use_stereo:=true cam_max_n:=2 lidar_enabled:=false gps_enabled:=false wheel_enabled:=true vicon_enabled:=false sim_const_planar:=true"

--- a/mins/cmake/ROS1.cmake
+++ b/mins/cmake/ROS1.cmake
@@ -154,3 +154,19 @@ else ()
             )
 
 endif ()
+
+##################################################
+# Unit tests (opt-in: cmake -DBUILD_TESTS=ON)
+##################################################
+option(BUILD_TESTS "Build unit tests (requires GTest; or use tests/CMakeLists.txt standalone)" OFF)
+if (BUILD_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+    file(GLOB MINS_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_*.cpp)
+    foreach(TEST_SOURCE ${MINS_TEST_SOURCES})
+        get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+        add_executable(${TEST_NAME} ${TEST_SOURCE})
+        target_link_libraries(${TEST_NAME} mins_lib GTest::gtest_main)
+        add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    endforeach()
+endif ()

--- a/mins/src/update/vicon/UpdaterVicon.cpp
+++ b/mins/src/update/vicon/UpdaterVicon.cpp
@@ -145,8 +145,8 @@ bool UpdaterVicon::update(ViconData m) {
   assert(success);
 
   MatrixXd H = MatrixXd::Zero(6, total_hx);
-  MatrixXd dz_dI, dz_dcalib_computed;
-  ComputeJacobians(R_GtoI, R_ItoX, p_IinX, dz_dI, dz_dcalib_computed);
+  MatrixXd dz_dI, dz_dcalib;
+  ComputeJacobians(R_GtoI, R_ItoX, p_IinX, dz_dI, dz_dcalib);
 
   // CHAINRULE: get state clone Jacobian. This also adds timeoffset jacobian
   for (int i = 0; i < (int)dTdx.size(); i++) {
@@ -156,7 +156,7 @@ bool UpdaterVicon::update(ViconData m) {
 
   // Extrinsic calibration
   if (state->op->vicon->do_calib_ext) {
-    H.block(0, map_hx.at(calibration), 6, calibration->size()).noalias() += dz_dcalib_computed;
+    H.block(0, map_hx.at(calibration), 6, calibration->size()).noalias() += dz_dcalib;
   }
 
   //=========================================================================

--- a/mins/src/update/vicon/UpdaterVicon.cpp
+++ b/mins/src/update/vicon/UpdaterVicon.cpp
@@ -56,34 +56,33 @@ void UpdaterVicon::try_update() {
   }
 }
 
-Matrix<double, 6, 1> UpdaterVicon::ComputeResidual(const Matrix3d &rotation_global_to_imu,
-                                                    const Vector3d &position_imu_in_global,
-                                                    const Matrix3d &rotation_imu_to_vicon,
-                                                    const Vector3d &position_imu_in_vicon,
-                                                    const Matrix<double, 6, 1> &measurement_pose) {
-  Vector3d position_vicon_in_imu = -rotation_imu_to_vicon.transpose() * position_imu_in_vicon;
-  Matrix3d rotation_imu_to_global = rotation_global_to_imu.transpose();
+Matrix<double, 6, 1> UpdaterVicon::ComputeResidual(const Matrix3d &R_GtoI,
+                                                    const Vector3d &p_IinG,
+                                                    const Matrix3d &R_ItoX,
+                                                    const Vector3d &p_IinX,
+                                                    const Matrix<double, 6, 1> &z) {
+  Vector3d p_XinI = -R_ItoX.transpose() * p_IinX;
+  Matrix3d R_ItoG = R_GtoI.transpose();
   Matrix<double, 6, 1> residual = Matrix<double, 6, 1>::Zero();
-  residual.head(3) = -log_so3(exp_so3(measurement_pose.head(3)) * (rotation_imu_to_vicon * rotation_global_to_imu).transpose());
-  residual.tail(3) = measurement_pose.tail(3) - (position_imu_in_global + rotation_imu_to_global * position_vicon_in_imu);
+  residual.head(3) = -log_so3(exp_so3(z.head(3)) * (R_ItoX * R_GtoI).transpose());
+  residual.tail(3) = z.tail(3) - (p_IinG + R_ItoG * p_XinI);
   return residual;
 }
 
-void UpdaterVicon::ComputeJacobians(const Matrix3d &rotation_global_to_imu,
-                                    const Matrix3d &rotation_imu_to_vicon,
-                                    const Vector3d &position_imu_in_vicon,
-                                    MatrixXd &dz_dI,
-                                    MatrixXd &dz_dcalib) {
-  Vector3d position_vicon_in_imu = -rotation_imu_to_vicon.transpose() * position_imu_in_vicon;
-  Matrix3d rotation_imu_to_global = rotation_global_to_imu.transpose();
-  dz_dI = MatrixXd::Zero(6, 6);
-  dz_dI.block(0, 0, 3, 3) = rotation_imu_to_vicon;
-  dz_dI.block(3, 0, 3, 3) = -rotation_imu_to_global * skew_x(position_vicon_in_imu);
+std::pair<MatrixXd, MatrixXd> UpdaterVicon::ComputeJacobians(const Matrix3d &R_GtoI,
+                                                              const Matrix3d &R_ItoX,
+                                                              const Vector3d &p_IinX) {
+  Vector3d p_XinI = -R_ItoX.transpose() * p_IinX;
+  Matrix3d R_ItoG = R_GtoI.transpose();
+  MatrixXd dz_dI = MatrixXd::Zero(6, 6);
+  dz_dI.block(0, 0, 3, 3) = R_ItoX;
+  dz_dI.block(3, 0, 3, 3) = -R_ItoG * skew_x(p_XinI);
   dz_dI.block(3, 3, 3, 3) = Matrix3d::Identity();
-  dz_dcalib = MatrixXd::Zero(6, 6);
+  MatrixXd dz_dcalib = MatrixXd::Zero(6, 6);
   dz_dcalib.block(0, 0, 3, 3) = Matrix3d::Identity();
-  dz_dcalib.block(3, 0, 3, 3) = rotation_imu_to_global * rotation_imu_to_vicon.transpose() * skew_x(position_imu_in_vicon);
-  dz_dcalib.block(3, 3, 3, 3) = -rotation_imu_to_global * rotation_imu_to_vicon.transpose();
+  dz_dcalib.block(3, 0, 3, 3) = R_ItoG * R_ItoX.transpose() * skew_x(p_IinX);
+  dz_dcalib.block(3, 3, 3, 3) = -R_ItoG * R_ItoX.transpose();
+  return {dz_dI, dz_dcalib};
 }
 
 bool UpdaterVicon::update(ViconData m) {
@@ -145,8 +144,7 @@ bool UpdaterVicon::update(ViconData m) {
   assert(success);
 
   MatrixXd H = MatrixXd::Zero(6, total_hx);
-  MatrixXd dz_dI, dz_dcalib;
-  ComputeJacobians(R_GtoI, R_ItoX, p_IinX, dz_dI, dz_dcalib);
+  const auto [dz_dI, dz_dcalib] = ComputeJacobians(R_GtoI, R_ItoX, p_IinX);
 
   // CHAINRULE: get state clone Jacobian. This also adds timeoffset jacobian
   for (int i = 0; i < (int)dTdx.size(); i++) {

--- a/mins/src/update/vicon/UpdaterVicon.cpp
+++ b/mins/src/update/vicon/UpdaterVicon.cpp
@@ -56,6 +56,36 @@ void UpdaterVicon::try_update() {
   }
 }
 
+Matrix<double, 6, 1> UpdaterVicon::ComputeResidual(const Matrix3d &rotation_global_to_imu,
+                                                    const Vector3d &position_imu_in_global,
+                                                    const Matrix3d &rotation_imu_to_vicon,
+                                                    const Vector3d &position_imu_in_vicon,
+                                                    const Matrix<double, 6, 1> &measurement_pose) {
+  Vector3d position_vicon_in_imu = -rotation_imu_to_vicon.transpose() * position_imu_in_vicon;
+  Matrix3d rotation_imu_to_global = rotation_global_to_imu.transpose();
+  Matrix<double, 6, 1> residual = Matrix<double, 6, 1>::Zero();
+  residual.head(3) = -log_so3(exp_so3(measurement_pose.head(3)) * (rotation_imu_to_vicon * rotation_global_to_imu).transpose());
+  residual.tail(3) = measurement_pose.tail(3) - (position_imu_in_global + rotation_imu_to_global * position_vicon_in_imu);
+  return residual;
+}
+
+void UpdaterVicon::ComputeJacobians(const Matrix3d &rotation_global_to_imu,
+                                    const Matrix3d &rotation_imu_to_vicon,
+                                    const Vector3d &position_imu_in_vicon,
+                                    MatrixXd &dz_dI,
+                                    MatrixXd &dz_dcalib) {
+  Vector3d position_vicon_in_imu = -rotation_imu_to_vicon.transpose() * position_imu_in_vicon;
+  Matrix3d rotation_imu_to_global = rotation_global_to_imu.transpose();
+  dz_dI = MatrixXd::Zero(6, 6);
+  dz_dI.block(0, 0, 3, 3) = rotation_imu_to_vicon;
+  dz_dI.block(3, 0, 3, 3) = -rotation_imu_to_global * skew_x(position_vicon_in_imu);
+  dz_dI.block(3, 3, 3, 3) = Matrix3d::Identity();
+  dz_dcalib = MatrixXd::Zero(6, 6);
+  dz_dcalib.block(0, 0, 3, 3) = Matrix3d::Identity();
+  dz_dcalib.block(3, 0, 3, 3) = rotation_imu_to_global * rotation_imu_to_vicon.transpose() * skew_x(position_imu_in_vicon);
+  dz_dcalib.block(3, 3, 3, 3) = -rotation_imu_to_global * rotation_imu_to_vicon.transpose();
+}
+
 bool UpdaterVicon::update(ViconData m) {
   //=========================================================================
   // Linear System
@@ -99,34 +129,24 @@ bool UpdaterVicon::update(ViconData m) {
   //=========================================================================
   // Residual
   //=========================================================================
-  // calib info
   Matrix3d R_ItoX = calibration->Rot();
   Vector3d p_IinX = calibration->pos();
-  Vector3d p_XinI = -R_ItoX.transpose() * p_IinX;
-  // State info
   Matrix3d R_GtoI;
   Vector3d p_IinG;
   if (!state->get_interpolated_pose(m.time + timeoffset->value()(0), R_GtoI, p_IinG))
     return false;
-  Matrix3d R_ItoG = R_GtoI.transpose();
-  // residual
-  VectorXd res = VectorXd::Zero(6);
-  res.head(3) = -log_so3(exp_so3(m.pose.head(3)) * (R_ItoX * R_GtoI).transpose());
-  res.tail(3) = m.pose.tail(3) - (p_IinG + R_ItoG * p_XinI);
+  VectorXd res = ComputeResidual(R_GtoI, p_IinG, R_ItoX, p_IinX, m.pose);
 
   //=========================================================================
   // Jacobian
   //=========================================================================
-  // Get Jacobian of interpolated pose in respect to the state
   vector<MatrixXd> dTdx;
   bool success = state->get_interpolated_jacobian(m.time + timeoffset->value()(0), R_GtoI, p_IinG, "VICON", m.id, dTdx, order);
   assert(success);
 
   MatrixXd H = MatrixXd::Zero(6, total_hx);
-  MatrixXd dz_dI = MatrixXd::Zero(6, 6);
-  dz_dI.block(0, 0, 3, 3) = R_ItoX;                   // dzR_dIR
-  dz_dI.block(3, 0, 3, 3) = -R_ItoG * skew_x(p_XinI); // dzp_dIR
-  dz_dI.block(3, 3, 3, 3) = Matrix3d::Identity();     // dzp_dIp
+  MatrixXd dz_dI, dz_dcalib_computed;
+  ComputeJacobians(R_GtoI, R_ItoX, p_IinX, dz_dI, dz_dcalib_computed);
 
   // CHAINRULE: get state clone Jacobian. This also adds timeoffset jacobian
   for (int i = 0; i < (int)dTdx.size(); i++) {
@@ -136,12 +156,7 @@ bool UpdaterVicon::update(ViconData m) {
 
   // Extrinsic calibration
   if (state->op->vicon->do_calib_ext) {
-    // Calculate the Jacobian
-    MatrixXd dz_dcalib = MatrixXd::Zero(6, 6);
-    dz_dcalib.block(0, 0, 3, 3) = Matrix3d::Identity();                                     // dzR_dCR
-    dz_dcalib.block(3, 0, 3, 3) = R_GtoI.transpose() * R_ItoX.transpose() * skew_x(p_IinX); // dzp_dCR
-    dz_dcalib.block(3, 3, 3, 3) = -R_GtoI.transpose() * R_ItoX.transpose();                 // dzp_dCp
-    H.block(0, map_hx.at(calibration), 6, calibration->size()).noalias() += dz_dcalib;
+    H.block(0, map_hx.at(calibration), 6, calibration->size()).noalias() += dz_dcalib_computed;
   }
 
   //=========================================================================

--- a/mins/src/update/vicon/UpdaterVicon.h
+++ b/mins/src/update/vicon/UpdaterVicon.h
@@ -21,6 +21,7 @@
 #ifndef MINS_UPDATERVICON_H
 #define MINS_UPDATERVICON_H
 
+#include <Eigen/Core>
 #include <deque>
 #include <map>
 #include <memory>
@@ -38,6 +39,21 @@ class UpdaterVicon {
 public:
   /// Vicon updater
   UpdaterVicon(shared_ptr<State> state);
+
+  /// Compute the 6-DOF Vicon residual (orientation 3-vec, then position 3-vec).
+  static Eigen::Matrix<double, 6, 1> ComputeResidual(const Eigen::Matrix3d &rotation_global_to_imu,
+                                                      const Eigen::Vector3d &position_imu_in_global,
+                                                      const Eigen::Matrix3d &rotation_imu_to_vicon,
+                                                      const Eigen::Vector3d &position_imu_in_vicon,
+                                                      const Eigen::Matrix<double, 6, 1> &measurement_pose);
+
+  /// Compute the analytical Jacobians of the Vicon residual w.r.t. IMU pose (dz_dI) and
+  /// extrinsic calibration (dz_dcalib). Both are 6x6; columns follow [delta_rotation, delta_position].
+  static void ComputeJacobians(const Eigen::Matrix3d &rotation_global_to_imu,
+                                const Eigen::Matrix3d &rotation_imu_to_vicon,
+                                const Eigen::Vector3d &position_imu_in_vicon,
+                                Eigen::MatrixXd &dz_dI,
+                                Eigen::MatrixXd &dz_dcalib);
 
   /// feed vicon measurement
   void feed_measurement(const ViconData &data);

--- a/mins/src/update/vicon/UpdaterVicon.h
+++ b/mins/src/update/vicon/UpdaterVicon.h
@@ -25,6 +25,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 using namespace std;
@@ -43,35 +44,32 @@ public:
   /**
    * \brief Compute the 6-DOF Vicon measurement residual.
    *
-   * \param[in] rotation_global_to_imu Rotation matrix from global frame to IMU frame.
-   * \param[in] position_imu_in_global Position of the IMU expressed in the global frame.
-   * \param[in] rotation_imu_to_vicon Rotation matrix from IMU frame to Vicon sensor frame.
-   * \param[in] position_imu_in_vicon Position of the IMU expressed in the Vicon sensor frame.
-   * \param[in] measurement_pose Stacked 6-vector [orientation_3, position_3] from the Vicon measurement.
+   * \param[in] R_GtoI Rotation matrix from global frame to IMU frame.
+   * \param[in] p_IinG Position of the IMU expressed in the global frame.
+   * \param[in] R_ItoX Rotation matrix from IMU frame to Vicon sensor frame.
+   * \param[in] p_IinX Position of the IMU expressed in the Vicon sensor frame.
+   * \param[in] z Stacked 6-vector [orientation_3, position_3] from the Vicon measurement.
    * \return Residual 6-vector [orientation_error_3, position_error_3].
    */
-  static Eigen::Matrix<double, 6, 1> ComputeResidual(const Eigen::Matrix3d &rotation_global_to_imu,
-                                                      const Eigen::Vector3d &position_imu_in_global,
-                                                      const Eigen::Matrix3d &rotation_imu_to_vicon,
-                                                      const Eigen::Vector3d &position_imu_in_vicon,
-                                                      const Eigen::Matrix<double, 6, 1> &measurement_pose);
+  static Eigen::Matrix<double, 6, 1> ComputeResidual(const Eigen::Matrix3d &R_GtoI,
+                                                      const Eigen::Vector3d &p_IinG,
+                                                      const Eigen::Matrix3d &R_ItoX,
+                                                      const Eigen::Vector3d &p_IinX,
+                                                      const Eigen::Matrix<double, 6, 1> &z);
 
   /**
    * \brief Compute analytical Jacobians of the Vicon residual.
    *
-   * Both output matrices are 6x6; columns follow [delta_rotation, delta_position].
+   * Both matrices are 6x6; columns follow [delta_rotation, delta_position].
    *
-   * \param[in] rotation_global_to_imu Rotation matrix from global frame to IMU frame.
-   * \param[in] rotation_imu_to_vicon Rotation matrix from IMU frame to Vicon sensor frame.
-   * \param[in] position_imu_in_vicon Position of the IMU expressed in the Vicon sensor frame.
-   * \param[out] dz_dI Jacobian of the residual with respect to the IMU pose state.
-   * \param[out] dz_dcalib Jacobian of the residual with respect to the extrinsic calibration.
+   * \param[in] R_GtoI Rotation matrix from global frame to IMU frame.
+   * \param[in] R_ItoX Rotation matrix from IMU frame to Vicon sensor frame.
+   * \param[in] p_IinX Position of the IMU expressed in the Vicon sensor frame.
+   * \return {dz_dI, dz_dcalib} — Jacobians w.r.t. IMU pose state and extrinsic calibration.
    */
-  static void ComputeJacobians(const Eigen::Matrix3d &rotation_global_to_imu,
-                                const Eigen::Matrix3d &rotation_imu_to_vicon,
-                                const Eigen::Vector3d &position_imu_in_vicon,
-                                Eigen::MatrixXd &dz_dI,
-                                Eigen::MatrixXd &dz_dcalib);
+  static std::pair<Eigen::MatrixXd, Eigen::MatrixXd> ComputeJacobians(const Eigen::Matrix3d &R_GtoI,
+                                                                        const Eigen::Matrix3d &R_ItoX,
+                                                                        const Eigen::Vector3d &p_IinX);
 
   /// feed vicon measurement
   void feed_measurement(const ViconData &data);

--- a/mins/src/update/vicon/UpdaterVicon.h
+++ b/mins/src/update/vicon/UpdaterVicon.h
@@ -40,15 +40,33 @@ public:
   /// Vicon updater
   UpdaterVicon(shared_ptr<State> state);
 
-  /// Compute the 6-DOF Vicon residual (orientation 3-vec, then position 3-vec).
+  /**
+   * \brief Compute the 6-DOF Vicon measurement residual.
+   *
+   * \param[in] rotation_global_to_imu Rotation matrix from global frame to IMU frame.
+   * \param[in] position_imu_in_global Position of the IMU expressed in the global frame.
+   * \param[in] rotation_imu_to_vicon Rotation matrix from IMU frame to Vicon sensor frame.
+   * \param[in] position_imu_in_vicon Position of the IMU expressed in the Vicon sensor frame.
+   * \param[in] measurement_pose Stacked 6-vector [orientation_3, position_3] from the Vicon measurement.
+   * \return Residual 6-vector [orientation_error_3, position_error_3].
+   */
   static Eigen::Matrix<double, 6, 1> ComputeResidual(const Eigen::Matrix3d &rotation_global_to_imu,
                                                       const Eigen::Vector3d &position_imu_in_global,
                                                       const Eigen::Matrix3d &rotation_imu_to_vicon,
                                                       const Eigen::Vector3d &position_imu_in_vicon,
                                                       const Eigen::Matrix<double, 6, 1> &measurement_pose);
 
-  /// Compute the analytical Jacobians of the Vicon residual w.r.t. IMU pose (dz_dI) and
-  /// extrinsic calibration (dz_dcalib). Both are 6x6; columns follow [delta_rotation, delta_position].
+  /**
+   * \brief Compute analytical Jacobians of the Vicon residual.
+   *
+   * Both output matrices are 6x6; columns follow [delta_rotation, delta_position].
+   *
+   * \param[in] rotation_global_to_imu Rotation matrix from global frame to IMU frame.
+   * \param[in] rotation_imu_to_vicon Rotation matrix from IMU frame to Vicon sensor frame.
+   * \param[in] position_imu_in_vicon Position of the IMU expressed in the Vicon sensor frame.
+   * \param[out] dz_dI Jacobian of the residual with respect to the IMU pose state.
+   * \param[out] dz_dcalib Jacobian of the residual with respect to the extrinsic calibration.
+   */
   static void ComputeJacobians(const Eigen::Matrix3d &rotation_global_to_imu,
                                 const Eigen::Matrix3d &rotation_imu_to_vicon,
                                 const Eigen::Vector3d &position_imu_in_vicon,

--- a/mins/tests/CMakeLists.txt
+++ b/mins/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.14)
+project(mins_tests)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.15.2)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+file(GLOB MINS_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp)
+foreach(TEST_SOURCE ${MINS_TEST_SOURCES})
+    get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
+    add_executable(${TEST_NAME} ${TEST_SOURCE})
+    target_link_libraries(${TEST_NAME} mins_lib GTest::gtest_main)
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endforeach()

--- a/mins/tests/test_UpdaterVicon.cpp
+++ b/mins/tests/test_UpdaterVicon.cpp
@@ -1,0 +1,105 @@
+// Numerically verifies UpdaterVicon's analytical Jacobians using central finite differences.
+// Perturbs each state dimension, collects residuals via UpdaterVicon::ComputeResidual,
+// builds H_numerical, and compares to UpdaterVicon::ComputeJacobians.
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+#include "update/vicon/UpdaterVicon.h"
+#include "update/vicon/ViconTypes.h"
+#include "utils/quat_ops.h"
+
+using namespace mins;
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+
+TEST(ViconJacobian, AnalyticalMatchesNumerical) {
+    // Rotation columns (0-2): H = d(residual)/d(delta_theta) — same sign as residual difference.
+    // Position columns (3-5): H = d(z_predicted)/d(delta_p) — opposite sign (r = z - h(x)).
+    // The sign multiplier below reflects this mixed convention.
+    const double epsilon = 1e-6;
+    const double tolerance = 1e-6;
+
+    Matrix3d rotation_global_to_imu = ov_core::exp_so3(Vector3d(0.1, -0.2, 0.15));
+    Vector3d position_imu_in_global(1.0, -0.5, 0.3);
+    Matrix3d rotation_imu_to_vicon = ov_core::exp_so3(Vector3d(-0.05, 0.1, 0.08));
+    Vector3d position_imu_in_vicon(0.1, 0.0, -0.2);
+
+    // Zero-residual nominal measurement.
+    Eigen::Matrix<double, 6, 1> measurement_pose = Eigen::Matrix<double, 6, 1>::Zero();
+    measurement_pose.head(3) = ov_core::log_so3(rotation_imu_to_vicon * rotation_global_to_imu);
+    measurement_pose.tail(3) = position_imu_in_global +
+                               rotation_global_to_imu.transpose() *
+                               (-rotation_imu_to_vicon.transpose() * position_imu_in_vicon);
+
+    // Analytical Jacobians from UpdaterVicon.
+    MatrixXd dz_dI, dz_dcalib;
+    UpdaterVicon::ComputeJacobians(rotation_global_to_imu, rotation_imu_to_vicon,
+                                   position_imu_in_vicon, dz_dI, dz_dcalib);
+
+    // --- dz_dI: perturb IMU pose ---
+    MatrixXd dz_dI_numerical = MatrixXd::Zero(6, 6);
+    for (int i = 0; i < 6; i++) {
+        Matrix3d R_plus = rotation_global_to_imu;
+        Matrix3d R_minus = rotation_global_to_imu;
+        Vector3d p_plus = position_imu_in_global;
+        Vector3d p_minus = position_imu_in_global;
+        if (i < 3) {
+            Vector3d axis = Vector3d::Zero();
+            axis(i) = 1.0;
+            R_plus = ov_core::exp_so3(epsilon * axis) * rotation_global_to_imu;
+            R_minus = ov_core::exp_so3(-epsilon * axis) * rotation_global_to_imu;
+        } else {
+            p_plus(i - 3) += epsilon;
+            p_minus(i - 3) -= epsilon;
+        }
+        Eigen::Matrix<double, 6, 1> res_plus =
+            UpdaterVicon::ComputeResidual(R_plus, p_plus, rotation_imu_to_vicon,
+                                          position_imu_in_vicon, measurement_pose);
+        Eigen::Matrix<double, 6, 1> res_minus =
+            UpdaterVicon::ComputeResidual(R_minus, p_minus, rotation_imu_to_vicon,
+                                          position_imu_in_vicon, measurement_pose);
+        // Rotation cols: H = d(r)/d(delta_theta); position cols: H = -d(r)/d(delta_p).
+        double sign = (i < 3) ? 1.0 : -1.0;
+        dz_dI_numerical.col(i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
+    }
+
+    for (int row = 0; row < 6; row++) {
+        for (int col = 0; col < 6; col++) {
+            EXPECT_NEAR(dz_dI(row, col), dz_dI_numerical(row, col), tolerance)
+                << "dz_dI mismatch at row=" << row << " col=" << col;
+        }
+    }
+
+    // --- dz_dcalib: perturb Vicon extrinsic calibration ---
+    MatrixXd dz_dcalib_numerical = MatrixXd::Zero(6, 6);
+    for (int i = 0; i < 6; i++) {
+        Matrix3d R_plus = rotation_imu_to_vicon;
+        Matrix3d R_minus = rotation_imu_to_vicon;
+        Vector3d p_plus = position_imu_in_vicon;
+        Vector3d p_minus = position_imu_in_vicon;
+        if (i < 3) {
+            Vector3d axis = Vector3d::Zero();
+            axis(i) = 1.0;
+            R_plus = ov_core::exp_so3(epsilon * axis) * rotation_imu_to_vicon;
+            R_minus = ov_core::exp_so3(-epsilon * axis) * rotation_imu_to_vicon;
+        } else {
+            p_plus(i - 3) += epsilon;
+            p_minus(i - 3) -= epsilon;
+        }
+        Eigen::Matrix<double, 6, 1> res_plus =
+            UpdaterVicon::ComputeResidual(rotation_global_to_imu, position_imu_in_global,
+                                          R_plus, p_plus, measurement_pose);
+        Eigen::Matrix<double, 6, 1> res_minus =
+            UpdaterVicon::ComputeResidual(rotation_global_to_imu, position_imu_in_global,
+                                          R_minus, p_minus, measurement_pose);
+        double sign = (i < 3) ? 1.0 : -1.0;
+        dz_dcalib_numerical.col(i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
+    }
+
+    for (int row = 0; row < 6; row++) {
+        for (int col = 0; col < 6; col++) {
+            EXPECT_NEAR(dz_dcalib(row, col), dz_dcalib_numerical(row, col), tolerance)
+                << "dz_dcalib mismatch at row=" << row << " col=" << col;
+        }
+    }
+}

--- a/mins/tests/test_UpdaterVicon.cpp
+++ b/mins/tests/test_UpdaterVicon.cpp
@@ -61,6 +61,10 @@ TEST(ViconJacobian, AnalyticalMatchesNumerical) {
         for (int col = 0; col < 6; col++) {
             EXPECT_NEAR(dz_dI(row, col), dz_dI_numerical(row, col), tolerance)
                 << "dz_dI mismatch at row=" << row << " col=" << col;
+            if (std::abs(dz_dI_numerical(row, col)) > tolerance) {
+                EXPECT_GT(dz_dI(row, col) * dz_dI_numerical(row, col), 0.0)
+                    << "dz_dI sign mismatch at row=" << row << " col=" << col;
+            }
         }
     }
 
@@ -92,6 +96,10 @@ TEST(ViconJacobian, AnalyticalMatchesNumerical) {
         for (int col = 0; col < 6; col++) {
             EXPECT_NEAR(dz_dcalib(row, col), dz_dcalib_numerical(row, col), tolerance)
                 << "dz_dcalib mismatch at row=" << row << " col=" << col;
+            if (std::abs(dz_dcalib_numerical(row, col)) > tolerance) {
+                EXPECT_GT(dz_dcalib(row, col) * dz_dcalib_numerical(row, col), 0.0)
+                    << "dz_dcalib sign mismatch at row=" << row << " col=" << col;
+            }
         }
     }
 }

--- a/mins/tests/test_UpdaterVicon.cpp
+++ b/mins/tests/test_UpdaterVicon.cpp
@@ -19,45 +19,39 @@ TEST(ViconJacobian, AnalyticalMatchesNumerical) {
     const double epsilon = 1e-6;
     const double tolerance = 1e-6;
 
-    Matrix3d rotation_global_to_imu = ov_core::exp_so3(Vector3d(0.1, -0.2, 0.15));
-    Vector3d position_imu_in_global(1.0, -0.5, 0.3);
-    Matrix3d rotation_imu_to_vicon = ov_core::exp_so3(Vector3d(-0.05, 0.1, 0.08));
-    Vector3d position_imu_in_vicon(0.1, 0.0, -0.2);
+    Matrix3d R_GtoI = ov_core::exp_so3(Vector3d(0.1, -0.2, 0.15));
+    Vector3d p_IinG(1.0, -0.5, 0.3);
+    Matrix3d R_ItoX = ov_core::exp_so3(Vector3d(-0.05, 0.1, 0.08));
+    Vector3d p_IinX(0.1, 0.0, -0.2);
 
     // Zero-residual nominal measurement.
-    Eigen::Matrix<double, 6, 1> measurement_pose = Eigen::Matrix<double, 6, 1>::Zero();
-    measurement_pose.head(3) = ov_core::log_so3(rotation_imu_to_vicon * rotation_global_to_imu);
-    measurement_pose.tail(3) = position_imu_in_global +
-                               rotation_global_to_imu.transpose() *
-                               (-rotation_imu_to_vicon.transpose() * position_imu_in_vicon);
+    Eigen::Matrix<double, 6, 1> z = Eigen::Matrix<double, 6, 1>::Zero();
+    z.head(3) = ov_core::log_so3(R_ItoX * R_GtoI);
+    z.tail(3) = p_IinG + R_GtoI.transpose() * (-R_ItoX.transpose() * p_IinX);
 
     // Analytical Jacobians from UpdaterVicon.
-    MatrixXd dz_dI, dz_dcalib;
-    UpdaterVicon::ComputeJacobians(rotation_global_to_imu, rotation_imu_to_vicon,
-                                   position_imu_in_vicon, dz_dI, dz_dcalib);
+    const auto [dz_dI, dz_dcalib] = UpdaterVicon::ComputeJacobians(R_GtoI, R_ItoX, p_IinX);
 
     // --- dz_dI: perturb IMU pose ---
     MatrixXd dz_dI_numerical = MatrixXd::Zero(6, 6);
     for (int i = 0; i < 6; i++) {
-        Matrix3d R_plus = rotation_global_to_imu;
-        Matrix3d R_minus = rotation_global_to_imu;
-        Vector3d p_plus = position_imu_in_global;
-        Vector3d p_minus = position_imu_in_global;
+        Matrix3d R_plus = R_GtoI;
+        Matrix3d R_minus = R_GtoI;
+        Vector3d p_plus = p_IinG;
+        Vector3d p_minus = p_IinG;
         if (i < 3) {
             Vector3d axis = Vector3d::Zero();
             axis(i) = 1.0;
-            R_plus = ov_core::exp_so3(epsilon * axis) * rotation_global_to_imu;
-            R_minus = ov_core::exp_so3(-epsilon * axis) * rotation_global_to_imu;
+            R_plus = ov_core::exp_so3(epsilon * axis) * R_GtoI;
+            R_minus = ov_core::exp_so3(-epsilon * axis) * R_GtoI;
         } else {
             p_plus(i - 3) += epsilon;
             p_minus(i - 3) -= epsilon;
         }
         Eigen::Matrix<double, 6, 1> res_plus =
-            UpdaterVicon::ComputeResidual(R_plus, p_plus, rotation_imu_to_vicon,
-                                          position_imu_in_vicon, measurement_pose);
+            UpdaterVicon::ComputeResidual(R_plus, p_plus, R_ItoX, p_IinX, z);
         Eigen::Matrix<double, 6, 1> res_minus =
-            UpdaterVicon::ComputeResidual(R_minus, p_minus, rotation_imu_to_vicon,
-                                          position_imu_in_vicon, measurement_pose);
+            UpdaterVicon::ComputeResidual(R_minus, p_minus, R_ItoX, p_IinX, z);
         // Rotation cols: H = d(r)/d(delta_theta); position cols: H = -d(r)/d(delta_p).
         double sign = (i < 3) ? 1.0 : -1.0;
         dz_dI_numerical.col(i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
@@ -73,25 +67,23 @@ TEST(ViconJacobian, AnalyticalMatchesNumerical) {
     // --- dz_dcalib: perturb Vicon extrinsic calibration ---
     MatrixXd dz_dcalib_numerical = MatrixXd::Zero(6, 6);
     for (int i = 0; i < 6; i++) {
-        Matrix3d R_plus = rotation_imu_to_vicon;
-        Matrix3d R_minus = rotation_imu_to_vicon;
-        Vector3d p_plus = position_imu_in_vicon;
-        Vector3d p_minus = position_imu_in_vicon;
+        Matrix3d R_plus = R_ItoX;
+        Matrix3d R_minus = R_ItoX;
+        Vector3d p_plus = p_IinX;
+        Vector3d p_minus = p_IinX;
         if (i < 3) {
             Vector3d axis = Vector3d::Zero();
             axis(i) = 1.0;
-            R_plus = ov_core::exp_so3(epsilon * axis) * rotation_imu_to_vicon;
-            R_minus = ov_core::exp_so3(-epsilon * axis) * rotation_imu_to_vicon;
+            R_plus = ov_core::exp_so3(epsilon * axis) * R_ItoX;
+            R_minus = ov_core::exp_so3(-epsilon * axis) * R_ItoX;
         } else {
             p_plus(i - 3) += epsilon;
             p_minus(i - 3) -= epsilon;
         }
         Eigen::Matrix<double, 6, 1> res_plus =
-            UpdaterVicon::ComputeResidual(rotation_global_to_imu, position_imu_in_global,
-                                          R_plus, p_plus, measurement_pose);
+            UpdaterVicon::ComputeResidual(R_GtoI, p_IinG, R_plus, p_plus, z);
         Eigen::Matrix<double, 6, 1> res_minus =
-            UpdaterVicon::ComputeResidual(rotation_global_to_imu, position_imu_in_global,
-                                          R_minus, p_minus, measurement_pose);
+            UpdaterVicon::ComputeResidual(R_GtoI, p_IinG, R_minus, p_minus, z);
         double sign = (i < 3) ? 1.0 : -1.0;
         dz_dcalib_numerical.col(i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
     }


### PR DESCRIPTION
## Summary

- Extract `ComputeResidual` and `ComputeJacobians` as public static methods from `UpdaterVicon` so tests can call actual MINS functions (no duplicated math)
- `test_UpdaterVicon.cpp`: builds a numerical Jacobian via central finite differences and compares to the analytical result (1e-6 tolerance) ? verifies both `dz_dI` (IMU pose) and `dz_dcalib` (extrinsic calibration) blocks
- `CMake`: `BUILD_TESTS=OFF` by default; auto-globs `tests/test_*.cpp` so new test files register with no cmake edits
- `CI`: Noetic `build_2004` job installs `libgtest-dev` and runs `ctest` after the smoke test

## Test plan

- [x] Test passes in WSL Noetic: `1/1 Test #1: test_UpdaterVicon ... Passed 0.05 sec`
- [ ] CI passes on this PR