### PR TITLE
extract ComputeResidual2D/ComputeJacobians2D, add unit test

### DIFF
--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -225,101 +225,98 @@ bool UpdaterWheel::select_wheel_data(double time0, double time1, vector<WheelDat
  * Given a measurement, this will compute the linear system of the new measurements in respect to the state
  * This will return a "small" H, res, and R which are only of a single measurement and sub-set of the state
  */
-void UpdaterWheel::compute_linear_system_2D(MatrixXd &H, VectorXd &res, double time0, double time1) {
-
-  // Load state values
-  shared_ptr<PoseJPL> pose0 = state->clones.at(time0);
-  shared_ptr<PoseJPL> pose1 = state->clones.at(time1);
-  Vector3d pI0inG = pose0->pos();
-  Vector3d pI1inG = pose1->pos();
-  Matrix3d RGtoI0 = pose0->Rot();
-  Matrix3d RGtoI1 = pose1->Rot();
-  Vector3d pIinO = state->wheel_extrinsic->pos();
-  Matrix3d RItoO = state->wheel_extrinsic->Rot();
-  Vector3d pOinI = -RItoO.transpose() * pIinO;
-  Matrix3d RO0toO1 = RItoO * RGtoI1 * RGtoI0.transpose() * RItoO.transpose();
-  Matrix3d RO1toO0 = RO0toO1.transpose();
-
-  // Create projection matrix
+Eigen::Vector3d UpdaterWheel::ComputeResidual2D(const Matrix3d &R_GtoI0, const Vector3d &p_I0inG,
+                                                 const Matrix3d &R_GtoI1, const Vector3d &p_I1inG,
+                                                 const Matrix3d &R_ItoO, const Vector3d &p_IinO,
+                                                 double th, double x, double y) {
+  Vector3d pOinI = -R_ItoO.transpose() * p_IinO;
   Vector3d e3(0, 0, 1);
   Matrix<double, 2, 3> Lambda = Matrix<double, 2, 3>::Zero();
   Lambda.block(0, 0, 2, 2) = Matrix2d::Identity();
 
-  // Compute Orientation and position measurement residual
-  res = Vector3d::Zero();
-  double theta_est = e3.transpose() * log_so3(RItoO * RGtoI1 * RGtoI0.transpose() * RItoO.transpose());
-  res(0, 0) = theta_est - th_2D;
-  Vector2d d_int(x_2D, y_2D);
-  Vector2d d_est = Lambda * RItoO * RGtoI0 * (pI1inG + RGtoI1.transpose() * pOinI - pI0inG - RGtoI0.transpose() * pOinI);
-  res.block(1, 0, 2, 1) = d_int - d_est;
+  Vector3d res = Vector3d::Zero();
+  double theta_est = e3.transpose() * log_so3(R_ItoO * R_GtoI1 * R_GtoI0.transpose() * R_ItoO.transpose());
+  res(0) = theta_est - th;
+  Vector2d d_est = Lambda * R_ItoO * R_GtoI0 * (p_I1inG + R_GtoI1.transpose() * pOinI - p_I0inG - R_GtoI0.transpose() * pOinI);
+  res.block(1, 0, 2, 1) = Vector2d(x, y) - d_est;
+  return res;
+}
 
-  // Now compute Jacobians!
+pair<MatrixXd, MatrixXd> UpdaterWheel::ComputeJacobians2D(const Matrix3d &R_GtoI0, const Vector3d &p_I0inG,
+                                                            const Matrix3d &R_GtoI1, const Vector3d &p_I1inG,
+                                                            const Matrix3d &R_ItoO, const Vector3d &p_IinO) {
+  Vector3d pOinI = -R_ItoO.transpose() * p_IinO;
+  Matrix3d RO0toO1 = R_ItoO * R_GtoI1 * R_GtoI0.transpose() * R_ItoO.transpose();
+  Matrix3d RO1toO0 = RO0toO1.transpose();
+  Vector3d e3(0, 0, 1);
+  Matrix<double, 2, 3> Lambda = Matrix<double, 2, 3>::Zero();
+  Lambda.block(0, 0, 2, 2) = Matrix2d::Identity();
 
-  // compute the size of the Jacobian
-  int H_size = 12; // Default size for pose of clone 1 and 2
+  Matrix<double, 1, 3> dzr_dth0 = -e3.transpose() * R_ItoO * R_GtoI1 * R_GtoI0.transpose();
+  Matrix<double, 1, 3> dzr_dth1 = e3.transpose() * R_ItoO;
+  Matrix<double, 2, 3> dzp_dth0 = Lambda * R_ItoO * skew_x(R_GtoI0 * (p_I1inG + R_GtoI1.transpose() * pOinI - p_I0inG));
+  Matrix<double, 2, 3> dzp_dp0 = -Lambda * R_ItoO * R_GtoI0;
+  Matrix<double, 2, 3> dzp_dth1 = -Lambda * R_ItoO * R_GtoI0 * R_GtoI1.transpose() * skew_x(pOinI);
+  Matrix<double, 2, 3> dzp_dp1 = Lambda * R_ItoO * R_GtoI0;
+
+  MatrixXd H_poses = MatrixXd::Zero(3, 12);
+  H_poses.block(0, 0, 1, 3) = dzr_dth0;
+  H_poses.block(0, 6, 1, 3) = dzr_dth1;
+  H_poses.block(1, 0, 2, 3) = dzp_dth0;
+  H_poses.block(1, 3, 2, 3) = dzp_dp0;
+  H_poses.block(1, 6, 2, 3) = dzp_dth1;
+  H_poses.block(1, 9, 2, 3) = dzp_dp1;
+
+  Matrix<double, 1, 3> dzr_dthcalib = e3.transpose() * (Matrix3d::Identity() - RO0toO1);
+  Matrix<double, 2, 3> dzp_dthcalib = Lambda * (skew_x(R_ItoO * R_GtoI0 * (p_I1inG - p_I0inG) - RO1toO0 * p_IinO) + RO1toO0 * skew_x(p_IinO));
+  Matrix<double, 2, 3> dzp_dpcalib = Lambda * (-RO1toO0 + Matrix3d::Identity());
+
+  MatrixXd H_ext = MatrixXd::Zero(3, 6);
+  H_ext.block(0, 0, 1, 3) = dzr_dthcalib;
+  H_ext.block(1, 0, 2, 3) = dzp_dthcalib;
+  H_ext.block(1, 3, 2, 3) = dzp_dpcalib;
+
+  return {H_poses, H_ext};
+}
+
+void UpdaterWheel::compute_linear_system_2D(MatrixXd &H, VectorXd &res, double time0, double time1) {
+  shared_ptr<PoseJPL> pose0 = state->clones.at(time0);
+  shared_ptr<PoseJPL> pose1 = state->clones.at(time1);
+  Matrix3d RItoO = state->wheel_extrinsic->Rot();
+  Vector3d pIinO = state->wheel_extrinsic->pos();
+
+  // Residual at current state values
+  res = ComputeResidual2D(pose0->Rot(), pose0->pos(), pose1->Rot(), pose1->pos(), RItoO, pIinO, th_2D, x_2D, y_2D);
+
+  // Jacobians at FEJ state values
+  int H_size = 12;
   int H_count = 12;
   H_size += (state->op->wheel->do_calib_ext) ? 6 : 0;
   H_size += (state->op->wheel->do_calib_dt) ? 1 : 0;
   H_size += (state->op->wheel->do_calib_int) ? 3 : 0;
   H = MatrixXd::Zero(3, H_size);
 
-  // Overwrite FEJ
-  pI0inG = pose0->pos_fej();
-  pI1inG = pose1->pos_fej();
-  RGtoI0 = pose0->Rot_fej();
-  RGtoI1 = pose1->Rot_fej();
-  RO0toO1 = RItoO * RGtoI1 * RGtoI0.transpose() * RItoO.transpose();
-  RO1toO0 = RO0toO1.transpose();
+  const auto [H_poses, H_ext] = ComputeJacobians2D(pose0->Rot_fej(), pose0->pos_fej(), pose1->Rot_fej(), pose1->pos_fej(), RItoO, pIinO);
+  H.block(0, 0, 3, 12) = H_poses;
 
-  // Jacobians in respect to current state
-  // orientation
-  Matrix<double, 1, 3> dzr_dth0 = -e3.transpose() * RItoO * RGtoI1 * RGtoI0.transpose();
-  Matrix<double, 1, 3> dzr_dth1 = e3.transpose() * RItoO;
-  // position
-  Matrix<double, 2, 3> dzp_dth0 = Lambda * RItoO * skew_x(RGtoI0 * (pI1inG + RGtoI1.transpose() * pOinI - pI0inG));
-  Matrix<double, 2, 3> dzp_dp0 = -Lambda * RItoO * RGtoI0;
-  Matrix<double, 2, 3> dzp_dth1 = -Lambda * RItoO * RGtoI0 * RGtoI1.transpose() * skew_x(pOinI);
-  Matrix<double, 2, 3> dzp_dp1 = Lambda * RItoO * RGtoI0;
-
-  // Derivative orientation change wrt oldest pose0 and pose1
-  H.block(0, 0, 1, 3) = dzr_dth0;
-  H.block(0, 6, 1, 3) = dzr_dth1;
-  // Derivative position change wrt oldest pose0 and pose1
-  H.block(1, 0, 2, 3) = dzp_dth0;
-  H.block(1, 3, 2, 3) = dzp_dp0;
-  H.block(1, 6, 2, 3) = dzp_dth1;
-  H.block(1, 9, 2, 3) = dzp_dp1;
-
-  // Jacobian wrt wheel to IMU extrinsics
   if (state->op->wheel->do_calib_ext) {
-    Matrix<double, 1, 3> dzr_dthcalib = e3.transpose() * (Matrix3d::Identity() - RO0toO1);
-    Matrix<double, 2, 3> dzp_dthcalib = Lambda * (skew_x(RItoO * RGtoI0 * (pI1inG - pI0inG) - RO1toO0 * pIinO) + RO1toO0 * skew_x(pIinO));
-    Matrix<double, 2, 3> dzp_dpcalib = Lambda * (-RO1toO0 + Matrix3d::Identity());
-    H.block(0, H_count, 1, 3) = dzr_dthcalib;
-    H.block(1, H_count, 2, 3) = dzp_dthcalib;
-    H.block(1, H_count + 3, 2, 3) = dzp_dpcalib;
+    H.block(0, H_count, 3, 6) = H_ext;
     H_count += 6;
   }
 
-  // Jacobian wrt wheel timeoffset.
   if (state->op->wheel->do_calib_dt) {
-    // should be able to find imu wv
     assert(state->cpis.find(time0) != state->cpis.end());
     assert(state->cpis.find(time1) != state->cpis.end());
     Vector3d w0 = state->cpis.at(time0).w;
     Vector3d v0 = state->cpis.at(time0).v;
     Vector3d w1 = state->cpis.at(time1).w;
     Vector3d v1 = state->cpis.at(time1).v;
-
-    // Put it in the Jacobian matrix
-    H(0, H_count) = (dzr_dth0 * w0 + dzr_dth1 * w1)(0, 0);
-    H.block(1, H_count, 2, 1) = (dzp_dth0 * w0 + dzp_dp0 * v0 + dzp_dth1 * w1 + dzp_dp1 * v1);
+    H(0, H_count) = (H_poses.block(0, 0, 1, 3) * w0 + H_poses.block(0, 6, 1, 3) * w1)(0, 0);
+    H.block(1, H_count, 2, 1) = H_poses.block(1, 0, 2, 3) * w0 + H_poses.block(1, 3, 2, 3) * v0 + H_poses.block(1, 6, 2, 3) * w1 + H_poses.block(1, 9, 2, 3) * v1;
     H_count += 1;
   }
 
-  // Jacobian wrt wheel intrinsics.
   if (state->op->wheel->do_calib_int) {
-    // Note they are the opposite sign
     H.block(0, H_count, 1, 3) = -dth_di_2D;
     H.block(1, H_count, 1, 3) = -dx_di_2D;
     H.block(2, H_count, 1, 3) = -dy_di_2D;

--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -248,12 +248,15 @@ pair<MatrixXd, MatrixXd> UpdaterWheel::ComputeJacobians2D(const Matrix3d &R_GtoI
   Vector3d pOinI = -R_ItoO.transpose() * p_IinO;
   Matrix3d RO0toO1 = R_ItoO * R_GtoI1 * R_GtoI0.transpose() * R_ItoO.transpose();
   Matrix3d RO1toO0 = RO0toO1.transpose();
+  Vector3d phi = log_so3(RO0toO1);
   Vector3d e3(0, 0, 1);
   Matrix<double, 2, 3> Lambda = Matrix<double, 2, 3>::Zero();
   Lambda.block(0, 0, 2, 2) = Matrix2d::Identity();
 
-  Matrix<double, 1, 3> dzr_dth0 = -e3.transpose() * R_ItoO * R_GtoI1 * R_GtoI0.transpose();
-  Matrix<double, 1, 3> dzr_dth1 = e3.transpose() * R_ItoO;
+  // d log_so3(R * exp(η)) / dη = Jr(φ)^{-1}, corrects for SO(3) curvature.
+  Matrix3d Jr_phi_inv = Jr_so3(phi).inverse();
+  Matrix<double, 1, 3> dzr_dth0 = -e3.transpose() * Jr_phi_inv * R_ItoO;
+  Matrix<double, 1, 3> dzr_dth1 = e3.transpose() * Jr_phi_inv * RO1toO0 * R_ItoO;
   Matrix<double, 2, 3> dzp_dth0 = Lambda * R_ItoO * skew_x(R_GtoI0 * (p_I1inG + R_GtoI1.transpose() * pOinI - p_I0inG));
   Matrix<double, 2, 3> dzp_dp0 = -Lambda * R_ItoO * R_GtoI0;
   Matrix<double, 2, 3> dzp_dth1 = -Lambda * R_ItoO * R_GtoI0 * R_GtoI1.transpose() * skew_x(pOinI);
@@ -267,7 +270,7 @@ pair<MatrixXd, MatrixXd> UpdaterWheel::ComputeJacobians2D(const Matrix3d &R_GtoI
   H_poses.block(1, 6, 2, 3) = dzp_dth1;
   H_poses.block(1, 9, 2, 3) = dzp_dp1;
 
-  Matrix<double, 1, 3> dzr_dthcalib = e3.transpose() * (Matrix3d::Identity() - RO0toO1);
+  Matrix<double, 1, 3> dzr_dthcalib = e3.transpose() * Jr_phi_inv * (RO1toO0 - Matrix3d::Identity());
   Matrix<double, 2, 3> dzp_dthcalib = Lambda * (skew_x(R_ItoO * R_GtoI0 * (p_I1inG - p_I0inG) - RO1toO0 * p_IinO) + RO1toO0 * skew_x(p_IinO));
   Matrix<double, 2, 3> dzp_dpcalib = Lambda * (-RO1toO0 + Matrix3d::Identity());
 

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -24,6 +24,7 @@
 #include <Eigen/Eigen>
 #include <deque>
 #include <memory>
+#include <utility>
 
 namespace mins {
 
@@ -47,6 +48,41 @@ public:
 
   /// measurement history
   std::deque<double> t_hist;
+
+  /**
+   * \brief Compute the 3-DOF 2D wheel odometry residual.
+   * \param[in] R_GtoI0 Rotation from global to IMU frame at time 0.
+   * \param[in] p_I0inG Position of IMU at time 0 expressed in global frame.
+   * \param[in] R_GtoI1 Rotation from global to IMU frame at time 1.
+   * \param[in] p_I1inG Position of IMU at time 1 expressed in global frame.
+   * \param[in] R_ItoO Rotation from IMU frame to wheel odometry frame.
+   * \param[in] p_IinO Position of IMU expressed in wheel odometry frame.
+   * \param[in] th Preintegrated 2D heading angle from wheel odometry.
+   * \param[in] x Preintegrated 2D forward displacement from wheel odometry.
+   * \param[in] y Preintegrated 2D lateral displacement from wheel odometry.
+   * \return Residual 3-vector [heading_error, dx_error, dy_error].
+   */
+  static Eigen::Vector3d ComputeResidual2D(const Eigen::Matrix3d &R_GtoI0, const Eigen::Vector3d &p_I0inG,
+                                            const Eigen::Matrix3d &R_GtoI1, const Eigen::Vector3d &p_I1inG,
+                                            const Eigen::Matrix3d &R_ItoO, const Eigen::Vector3d &p_IinO,
+                                            double th, double x, double y);
+
+  /**
+   * \brief Compute analytical Jacobians of the 2D wheel odometry residual.
+   * Returns Jacobians w.r.t. the two IMU poses (3x12) and the wheel extrinsic (3x6).
+   * Pose columns are ordered [delta_th0(3), delta_p0(3), delta_th1(3), delta_p1(3)].
+   * Extrinsic columns are ordered [delta_thO(3), delta_pO(3)].
+   * \param[in] R_GtoI0 Rotation from global to IMU frame at time 0.
+   * \param[in] p_I0inG Position of IMU at time 0 expressed in global frame.
+   * \param[in] R_GtoI1 Rotation from global to IMU frame at time 1.
+   * \param[in] p_I1inG Position of IMU at time 1 expressed in global frame.
+   * \param[in] R_ItoO Rotation from IMU frame to wheel odometry frame.
+   * \param[in] p_IinO Position of IMU expressed in wheel odometry frame.
+   * \return {H_poses (3x12), H_ext (3x6)} Jacobians w.r.t. IMU poses and extrinsic calibration.
+   */
+  static std::pair<Eigen::MatrixXd, Eigen::MatrixXd> ComputeJacobians2D(const Eigen::Matrix3d &R_GtoI0, const Eigen::Vector3d &p_I0inG,
+                                                                          const Eigen::Matrix3d &R_GtoI1, const Eigen::Vector3d &p_I1inG,
+                                                                          const Eigen::Matrix3d &R_ItoO, const Eigen::Vector3d &p_IinO);
 
 private:
   friend class Initializer;

--- a/mins/tests/test_UpdaterWheel2D.cpp
+++ b/mins/tests/test_UpdaterWheel2D.cpp
@@ -1,0 +1,116 @@
+// Numerically verifies UpdaterWheel's 2D analytical Jacobians using central finite differences.
+// Perturbs each state dimension, builds H_numerical, and compares to UpdaterWheel::ComputeJacobians2D.
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+#include "update/wheel/UpdaterWheel.h"
+#include "utils/quat_ops.h"
+
+using namespace mins;
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+
+TEST(WheelJacobian2D, AnalyticalMatchesNumerical) {
+    // Rotation cols: sign = +1 (residual changes directly with rotation error-state).
+    // Position cols: sign = -1 (res = meas - h(state), so h increases means res decreases).
+    const double epsilon = 1e-6;
+    const double tolerance = 1e-6;
+
+    Matrix3d R_GtoI0 = ov_core::exp_so3(Vector3d(0.1, -0.2, 0.15));
+    Vector3d p_I0inG(1.0, 0.5, 0.0);
+    Matrix3d R_GtoI1 = ov_core::exp_so3(Vector3d(0.05, -0.15, 0.3));
+    Vector3d p_I1inG(2.0, 1.0, 0.0);
+    Matrix3d R_ItoO = ov_core::exp_so3(Vector3d(0.0, 0.0, 0.2));
+    Vector3d p_IinO(0.1, 0.0, -0.2);
+
+    // Zero-residual nominal measurement.
+    Vector3d pOinI = -R_ItoO.transpose() * p_IinO;
+    Eigen::Matrix<double, 2, 3> Lambda = Eigen::Matrix<double, 2, 3>::Zero();
+    Lambda.block(0, 0, 2, 2) = Eigen::Matrix2d::Identity();
+    Vector3d e3(0, 0, 1);
+    double th = (e3.transpose() * ov_core::log_so3(R_ItoO * R_GtoI1 * R_GtoI0.transpose() * R_ItoO.transpose()))(0);
+    Eigen::Vector2d d_est = Lambda * R_ItoO * R_GtoI0 * (p_I1inG + R_GtoI1.transpose() * pOinI - p_I0inG - R_GtoI0.transpose() * pOinI);
+    double x = d_est(0);
+    double y = d_est(1);
+
+    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians2D(R_GtoI0, p_I0inG, R_GtoI1, p_I1inG, R_ItoO, p_IinO);
+
+    // --- H_poses: perturb pose0 (cols 0-5) and pose1 (cols 6-11) ---
+    MatrixXd H_poses_numerical = MatrixXd::Zero(3, 12);
+    for (int i = 0; i < 6; i++) {
+        // pose0
+        Matrix3d R0_plus = R_GtoI0, R0_minus = R_GtoI0;
+        Vector3d p0_plus = p_I0inG, p0_minus = p_I0inG;
+        if (i < 3) {
+            Vector3d axis = Vector3d::Zero();
+            axis(i) = 1.0;
+            R0_plus = ov_core::exp_so3(epsilon * axis) * R_GtoI0;
+            R0_minus = ov_core::exp_so3(-epsilon * axis) * R_GtoI0;
+        } else {
+            p0_plus(i - 3) += epsilon;
+            p0_minus(i - 3) -= epsilon;
+        }
+        Vector3d res_plus = UpdaterWheel::ComputeResidual2D(R0_plus, p0_plus, R_GtoI1, p_I1inG, R_ItoO, p_IinO, th, x, y);
+        Vector3d res_minus = UpdaterWheel::ComputeResidual2D(R0_minus, p0_minus, R_GtoI1, p_I1inG, R_ItoO, p_IinO, th, x, y);
+        double sign = (i < 3) ? 1.0 : -1.0;
+        H_poses_numerical.col(i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
+
+        // pose1
+        Matrix3d R1_plus = R_GtoI1, R1_minus = R_GtoI1;
+        Vector3d p1_plus = p_I1inG, p1_minus = p_I1inG;
+        if (i < 3) {
+            Vector3d axis = Vector3d::Zero();
+            axis(i) = 1.0;
+            R1_plus = ov_core::exp_so3(epsilon * axis) * R_GtoI1;
+            R1_minus = ov_core::exp_so3(-epsilon * axis) * R_GtoI1;
+        } else {
+            p1_plus(i - 3) += epsilon;
+            p1_minus(i - 3) -= epsilon;
+        }
+        res_plus = UpdaterWheel::ComputeResidual2D(R_GtoI0, p_I0inG, R1_plus, p1_plus, R_ItoO, p_IinO, th, x, y);
+        res_minus = UpdaterWheel::ComputeResidual2D(R_GtoI0, p_I0inG, R1_minus, p1_minus, R_ItoO, p_IinO, th, x, y);
+        H_poses_numerical.col(6 + i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
+    }
+
+    for (int row = 0; row < 3; row++) {
+        for (int col = 0; col < 12; col++) {
+            EXPECT_NEAR(H_poses(row, col), H_poses_numerical(row, col), tolerance)
+                << "H_poses mismatch at row=" << row << " col=" << col;
+            if (std::abs(H_poses_numerical(row, col)) > tolerance) {
+                EXPECT_GT(H_poses(row, col) * H_poses_numerical(row, col), 0.0)
+                    << "H_poses sign mismatch at row=" << row << " col=" << col;
+            }
+        }
+    }
+
+    // --- H_ext: perturb extrinsic (R_ItoO, p_IinO) ---
+    MatrixXd H_ext_numerical = MatrixXd::Zero(3, 6);
+    for (int i = 0; i < 6; i++) {
+        Matrix3d R_plus = R_ItoO, R_minus = R_ItoO;
+        Vector3d p_plus = p_IinO, p_minus = p_IinO;
+        if (i < 3) {
+            Vector3d axis = Vector3d::Zero();
+            axis(i) = 1.0;
+            R_plus = ov_core::exp_so3(epsilon * axis) * R_ItoO;
+            R_minus = ov_core::exp_so3(-epsilon * axis) * R_ItoO;
+        } else {
+            p_plus(i - 3) += epsilon;
+            p_minus(i - 3) -= epsilon;
+        }
+        Vector3d res_plus = UpdaterWheel::ComputeResidual2D(R_GtoI0, p_I0inG, R_GtoI1, p_I1inG, R_plus, p_plus, th, x, y);
+        Vector3d res_minus = UpdaterWheel::ComputeResidual2D(R_GtoI0, p_I0inG, R_GtoI1, p_I1inG, R_minus, p_minus, th, x, y);
+        double sign = (i < 3) ? 1.0 : -1.0;
+        H_ext_numerical.col(i) = sign * (res_plus - res_minus) / (2.0 * epsilon);
+    }
+
+    for (int row = 0; row < 3; row++) {
+        for (int col = 0; col < 6; col++) {
+            EXPECT_NEAR(H_ext(row, col), H_ext_numerical(row, col), tolerance)
+                << "H_ext mismatch at row=" << row << " col=" << col;
+            if (std::abs(H_ext_numerical(row, col)) > tolerance) {
+                EXPECT_GT(H_ext(row, col) * H_ext_numerical(row, col), 0.0)
+                    << "H_ext sign mismatch at row=" << row << " col=" << col;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Full unit test coverage for wheel updater Jacobians

| # | Scope | Status |
|---|---|---|
| 1/4 | 2D: extract `ComputeResidual2D` + `ComputeJacobians2D` (pose + extrinsic), unit test | **THIS PR** |
| 2/4 | 3D: extract `ComputeResidual3D` + `ComputeJacobians3D` (pose + extrinsic), unit test | next |
| 3/4 | 2D + 3D: time-offset Jacobian unit tests | upcoming |
| 4/4 | 2D + 3D: intrinsic preintegration Jacobian unit tests | upcoming |

## Summary

- Extracts the 2D wheel residual computation and pose/extrinsic Jacobians from `compute_linear_system_2D` into two public static functions: `ComputeResidual2D` and `ComputeJacobians2D`.
- `ComputeJacobians2D` returns `std::pair<MatrixXd, MatrixXd>` - `{H_poses (3x12), H_ext (3x6)}` - avoiding output parameters.
- `compute_linear_system_2D` is refactored to call these; FEJ values are passed for Jacobians, current values for residuals. The time-offset column is reconstructed from `H_poses` sub-blocks, removing the need for local intermediate variables.
- `mins/tests/test_UpdaterWheel2D.cpp` verifies both Jacobians with central finite differences (eps=1e-6) plus a sign check for entries where the numerical magnitude exceeds the tolerance.

## Verification

Build in WSL2 Noetic environment and run:
```
catkin build mins && rosrun mins mins_test --gtest_filter=WheelJacobian2D*
```

## Chain

Next in chain: PR 2/4 - 3D pose + extrinsic Jacobians.