### PR TITLE
extract ComputeTimeOffsetJacobian2D/3D, add time-offset unit test (3/4)

### DIFF
--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -310,12 +310,8 @@ void UpdaterWheel::compute_linear_system_2D(MatrixXd &H, VectorXd &res, double t
   if (state->op->wheel->do_calib_dt) {
     assert(state->cpis.find(time0) != state->cpis.end());
     assert(state->cpis.find(time1) != state->cpis.end());
-    Vector3d w0 = state->cpis.at(time0).w;
-    Vector3d v0 = state->cpis.at(time0).v;
-    Vector3d w1 = state->cpis.at(time1).w;
-    Vector3d v1 = state->cpis.at(time1).v;
-    H(0, H_count) = (H_poses.block(0, 0, 1, 3) * w0 + H_poses.block(0, 6, 1, 3) * w1)(0, 0);
-    H.block(1, H_count, 2, 1) = H_poses.block(1, 0, 2, 3) * w0 + H_poses.block(1, 3, 2, 3) * v0 + H_poses.block(1, 6, 2, 3) * w1 + H_poses.block(1, 9, 2, 3) * v1;
+    H.col(H_count) = ComputeTimeOffsetJacobian2D(H_poses, state->cpis.at(time0).w, state->cpis.at(time0).v,
+                                                  state->cpis.at(time1).w, state->cpis.at(time1).v);
     H_count += 1;
   }
 
@@ -372,6 +368,22 @@ pair<MatrixXd, MatrixXd> UpdaterWheel::ComputeJacobians3D(const Matrix3d &R_GtoI
   return {H_poses, H_ext};
 }
 
+Vector3d UpdaterWheel::ComputeTimeOffsetJacobian2D(const MatrixXd &H_poses,
+                                                    const Vector3d &w0, const Vector3d &v0,
+                                                    const Vector3d &w1, const Vector3d &v1) {
+  Matrix<double, 12, 1> vel;
+  vel << w0, v0, w1, v1;
+  return H_poses * vel;
+}
+
+Matrix<double, 6, 1> UpdaterWheel::ComputeTimeOffsetJacobian3D(const MatrixXd &H_poses,
+                                                                 const Vector3d &w0, const Vector3d &v0,
+                                                                 const Vector3d &w1, const Vector3d &v1) {
+  Matrix<double, 12, 1> vel;
+  vel << w0, v0, w1, v1;
+  return H_poses * vel;
+}
+
 void UpdaterWheel::compute_linear_system_3D(MatrixXd &H, VectorXd &res, double time0, double time1) {
   shared_ptr<PoseJPL> pose0 = state->clones.at(time0);
   shared_ptr<PoseJPL> pose1 = state->clones.at(time1);
@@ -395,12 +407,8 @@ void UpdaterWheel::compute_linear_system_3D(MatrixXd &H, VectorXd &res, double t
   if (state->op->wheel->do_calib_dt) {
     assert(state->cpis.find(time0) != state->cpis.end());
     assert(state->cpis.find(time1) != state->cpis.end());
-    Vector3d w0 = state->cpis.at(time0).w;
-    Vector3d v0 = state->cpis.at(time0).v;
-    Vector3d w1 = state->cpis.at(time1).w;
-    Vector3d v1 = state->cpis.at(time1).v;
-    H.block(0, H_count, 3, 1) = H_poses.block(0, 0, 3, 3) * w0 + H_poses.block(0, 6, 3, 3) * w1;
-    H.block(3, H_count, 3, 1) = H_poses.block(3, 0, 3, 3) * w0 + H_poses.block(3, 3, 3, 3) * v0 + H_poses.block(3, 6, 3, 3) * w1 + H_poses.block(3, 9, 3, 3) * v1;
+    H.col(H_count) = ComputeTimeOffsetJacobian3D(H_poses, state->cpis.at(time0).w, state->cpis.at(time0).v,
+                                                  state->cpis.at(time1).w, state->cpis.at(time1).v);
     H_count += 1;
   }
   if (state->op->wheel->do_calib_int) {

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -118,6 +118,42 @@ public:
                                                                           const Eigen::Matrix3d &R_GtoI1, const Eigen::Vector3d &p_I1inG,
                                                                           const Eigen::Matrix3d &R_ItoO, const Eigen::Vector3d &p_IinO);
 
+  /**
+   * \brief Compute the time-offset Jacobian column for the 2D wheel odometry residual.
+   *
+   * Returns d(res)/d(dt) via the chain rule: H_poses * [w0; v0; w1; v1].
+   * w0/w1 are body-frame angular velocities; v0/v1 are global-frame linear velocities
+   * at each clone time, matching the cpis.w / cpis.v convention.
+   *
+   * \param[in] H_poses Pose Jacobian (3x12) from ComputeJacobians2D, evaluated at FEJ values.
+   * \param[in] w0 Angular velocity at time 0 (body frame).
+   * \param[in] v0 Linear velocity at time 0 (global frame).
+   * \param[in] w1 Angular velocity at time 1 (body frame).
+   * \param[in] v1 Linear velocity at time 1 (global frame).
+   * \return Time-offset Jacobian column (3x1).
+   */
+  static Eigen::Vector3d ComputeTimeOffsetJacobian2D(const Eigen::MatrixXd &H_poses,
+                                                      const Eigen::Vector3d &w0, const Eigen::Vector3d &v0,
+                                                      const Eigen::Vector3d &w1, const Eigen::Vector3d &v1);
+
+  /**
+   * \brief Compute the time-offset Jacobian column for the 3D wheel odometry residual.
+   *
+   * Returns d(res)/d(dt) via the chain rule: H_poses * [w0; v0; w1; v1].
+   * w0/w1 are body-frame angular velocities; v0/v1 are global-frame linear velocities
+   * at each clone time, matching the cpis.w / cpis.v convention.
+   *
+   * \param[in] H_poses Pose Jacobian (6x12) from ComputeJacobians3D, evaluated at FEJ values.
+   * \param[in] w0 Angular velocity at time 0 (body frame).
+   * \param[in] v0 Linear velocity at time 0 (global frame).
+   * \param[in] w1 Angular velocity at time 1 (body frame).
+   * \param[in] v1 Linear velocity at time 1 (global frame).
+   * \return Time-offset Jacobian column (6x1).
+   */
+  static Eigen::Matrix<double, 6, 1> ComputeTimeOffsetJacobian3D(const Eigen::MatrixXd &H_poses,
+                                                                   const Eigen::Vector3d &w0, const Eigen::Vector3d &v0,
+                                                                   const Eigen::Vector3d &w1, const Eigen::Vector3d &v1);
+
 private:
   friend class Initializer;
   friend class IW_Initializer;

--- a/mins/tests/test_UpdaterWheelDt.cpp
+++ b/mins/tests/test_UpdaterWheelDt.cpp
@@ -58,6 +58,10 @@ TEST(WheelTimeOffset2D, AnalyticalMatchesNumerical) {
     for (int i = 0; i < 3; i++) {
         EXPECT_NEAR(H_dt(i), H_dt_numerical(i), tol)
             << "2D H_dt mismatch at row=" << i;
+        if (std::abs(H_dt_numerical(i)) > tol) {
+            EXPECT_GT(H_dt(i) * H_dt_numerical(i), 0.0)
+                << "2D H_dt sign mismatch at row=" << i;
+        }
     }
 }
 
@@ -100,39 +104,9 @@ TEST(WheelTimeOffset3D, AnalyticalMatchesNumerical) {
     for (int i = 0; i < 6; i++) {
         EXPECT_NEAR(H_dt(i), H_dt_numerical(i), tol)
             << "3D H_dt mismatch at row=" << i;
+        if (std::abs(H_dt_numerical(i)) > tol) {
+            EXPECT_GT(H_dt(i) * H_dt_numerical(i), 0.0)
+                << "3D H_dt sign mismatch at row=" << i;
+        }
     }
-}
-
-// Identity configuration: all rotations I, all positions zero.
-// Jacobians reduce to closed-form scalars, so sign is unambiguous.
-TEST(WheelTimeOffset2D, SignCheck) {
-    Matrix3d I3 = Matrix3d::Identity();
-    Vector3d zero = Vector3d::Zero();
-    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians2D(I3, zero, I3, zero, I3, zero);
-
-    // v1 forward: x-residual grows when dt increases (later pose travels further).
-    Vector3d H_v1 = UpdaterWheel::ComputeTimeOffsetJacobian2D(H_poses, zero, zero, zero, Vector3d(1, 0, 0));
-    EXPECT_GT(H_v1(1), 0.0);
-
-    // v0 forward: x-residual shrinks when dt increases (earlier pose also shifts back).
-    Vector3d H_v0 = UpdaterWheel::ComputeTimeOffsetJacobian2D(H_poses, zero, Vector3d(1, 0, 0), zero, zero);
-    EXPECT_LT(H_v0(1), 0.0);
-}
-
-TEST(WheelTimeOffset3D, SignCheck) {
-    Matrix3d I3 = Matrix3d::Identity();
-    Vector3d zero = Vector3d::Zero();
-    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians3D(I3, zero, I3, zero, I3, zero);
-
-    // w1 = (0,0,1): rotation residual z grows when dt increases.
-    Eigen::Matrix<double, 6, 1> H_w1 = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, zero, zero, Vector3d(0, 0, 1), zero);
-    EXPECT_GT(H_w1(2), 0.0);
-
-    // v1 = (1,0,0): translation residual x grows when dt increases.
-    Eigen::Matrix<double, 6, 1> H_v1 = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, zero, zero, zero, Vector3d(1, 0, 0));
-    EXPECT_GT(H_v1(3), 0.0);
-
-    // v0 = (1,0,0): translation residual x shrinks when dt increases.
-    Eigen::Matrix<double, 6, 1> H_v0 = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, zero, Vector3d(1, 0, 0), zero, zero);
-    EXPECT_LT(H_v0(3), 0.0);
 }

--- a/mins/tests/test_UpdaterWheelDt.cpp
+++ b/mins/tests/test_UpdaterWheelDt.cpp
@@ -102,3 +102,37 @@ TEST(WheelTimeOffset3D, AnalyticalMatchesNumerical) {
             << "3D H_dt mismatch at row=" << i;
     }
 }
+
+// Identity configuration: all rotations I, all positions zero.
+// Jacobians reduce to closed-form scalars, so sign is unambiguous.
+TEST(WheelTimeOffset2D, SignCheck) {
+    Matrix3d I3 = Matrix3d::Identity();
+    Vector3d zero = Vector3d::Zero();
+    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians2D(I3, zero, I3, zero, I3, zero);
+
+    // v1 forward: x-residual grows when dt increases (later pose travels further).
+    Vector3d H_v1 = UpdaterWheel::ComputeTimeOffsetJacobian2D(H_poses, zero, zero, zero, Vector3d(1, 0, 0));
+    EXPECT_GT(H_v1(1), 0.0);
+
+    // v0 forward: x-residual shrinks when dt increases (earlier pose also shifts back).
+    Vector3d H_v0 = UpdaterWheel::ComputeTimeOffsetJacobian2D(H_poses, zero, Vector3d(1, 0, 0), zero, zero);
+    EXPECT_LT(H_v0(1), 0.0);
+}
+
+TEST(WheelTimeOffset3D, SignCheck) {
+    Matrix3d I3 = Matrix3d::Identity();
+    Vector3d zero = Vector3d::Zero();
+    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians3D(I3, zero, I3, zero, I3, zero);
+
+    // w1 = (0,0,1): rotation residual z grows when dt increases.
+    Eigen::Matrix<double, 6, 1> H_w1 = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, zero, zero, Vector3d(0, 0, 1), zero);
+    EXPECT_GT(H_w1(2), 0.0);
+
+    // v1 = (1,0,0): translation residual x grows when dt increases.
+    Eigen::Matrix<double, 6, 1> H_v1 = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, zero, zero, zero, Vector3d(1, 0, 0));
+    EXPECT_GT(H_v1(3), 0.0);
+
+    // v0 = (1,0,0): translation residual x shrinks when dt increases.
+    Eigen::Matrix<double, 6, 1> H_v0 = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, zero, Vector3d(1, 0, 0), zero, zero);
+    EXPECT_LT(H_v0(3), 0.0);
+}

--- a/mins/tests/test_UpdaterWheelDt.cpp
+++ b/mins/tests/test_UpdaterWheelDt.cpp
@@ -1,0 +1,104 @@
+// Numerically verifies the time-offset Jacobian (ComputeTimeOffsetJacobian2D/3D) via
+// a combined central finite difference: both clone poses are shifted simultaneously
+// by (exp_so3(w*eps)*R, p - v*eps), which models increasing dt by eps (backward shift).
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+#include "update/wheel/UpdaterWheel.h"
+#include "utils/quat_ops.h"
+
+using namespace mins;
+using Eigen::Matrix3d;
+using Eigen::MatrixXd;
+using Eigen::Vector3d;
+
+TEST(WheelTimeOffset2D, AnalyticalMatchesNumerical) {
+    const double eps = 1e-6;
+    const double tol = 1e-6;
+
+    Matrix3d R_GtoI0 = ov_core::exp_so3(Vector3d(0.1, -0.2, 0.15));
+    Vector3d p_I0inG(1.0, 0.5, 0.0);
+    Matrix3d R_GtoI1 = ov_core::exp_so3(Vector3d(0.05, -0.15, 0.3));
+    Vector3d p_I1inG(2.0, 1.0, 0.0);
+    Matrix3d R_ItoO = ov_core::exp_so3(Vector3d(0.0, 0.0, 0.2));
+    Vector3d p_IinO(0.1, 0.0, -0.2);
+
+    // Arbitrary velocities: w in body frame, v in global frame.
+    Vector3d w0(0.01, 0.02, 0.1), v0(0.5, 0.1, 0.0);
+    Vector3d w1(0.02, -0.01, 0.05), v1(0.6, -0.1, 0.0);
+
+    // Zero-residual nominal 2D measurement.
+    Vector3d pOinI = -R_ItoO.transpose() * p_IinO;
+    Vector3d e3(0, 0, 1);
+    Eigen::Matrix<double, 2, 3> Lambda = Eigen::Matrix<double, 2, 3>::Zero();
+    Lambda.block(0, 0, 2, 2) = Eigen::Matrix2d::Identity();
+    Matrix3d RO0toO1 = R_ItoO * R_GtoI1 * R_GtoI0.transpose() * R_ItoO.transpose();
+    double th = e3.dot(ov_core::log_so3(RO0toO1));
+    Eigen::Vector2d d_est = Lambda * R_ItoO * R_GtoI0 * (p_I1inG + R_GtoI1.transpose() * pOinI - p_I0inG - R_GtoI0.transpose() * pOinI);
+    double x = d_est(0), y = d_est(1);
+
+    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians2D(R_GtoI0, p_I0inG, R_GtoI1, p_I1inG, R_ItoO, p_IinO);
+    Vector3d H_dt = UpdaterWheel::ComputeTimeOffsetJacobian2D(H_poses, w0, v0, w1, v1);
+
+    // Combined FD: shift both poses backward in time by eps (models dt += eps).
+    // R(t-eps) ~ exp_so3(w*eps)*R,  p(t-eps) ~ p - v*eps.
+    Matrix3d R0p = ov_core::exp_so3(w0 * eps) * R_GtoI0;
+    Vector3d p0p = p_I0inG - v0 * eps;
+    Matrix3d R1p = ov_core::exp_so3(w1 * eps) * R_GtoI1;
+    Vector3d p1p = p_I1inG - v1 * eps;
+
+    Matrix3d R0m = ov_core::exp_so3(-w0 * eps) * R_GtoI0;
+    Vector3d p0m = p_I0inG + v0 * eps;
+    Matrix3d R1m = ov_core::exp_so3(-w1 * eps) * R_GtoI1;
+    Vector3d p1m = p_I1inG + v1 * eps;
+
+    Vector3d res_plus = UpdaterWheel::ComputeResidual2D(R0p, p0p, R1p, p1p, R_ItoO, p_IinO, th, x, y);
+    Vector3d res_minus = UpdaterWheel::ComputeResidual2D(R0m, p0m, R1m, p1m, R_ItoO, p_IinO, th, x, y);
+    Vector3d H_dt_numerical = (res_plus - res_minus) / (2.0 * eps);
+
+    for (int i = 0; i < 3; i++) {
+        EXPECT_NEAR(H_dt(i), H_dt_numerical(i), tol)
+            << "2D H_dt mismatch at row=" << i;
+    }
+}
+
+TEST(WheelTimeOffset3D, AnalyticalMatchesNumerical) {
+    const double eps = 1e-6;
+    const double tol = 1e-6;
+
+    Matrix3d R_GtoI0 = ov_core::exp_so3(Vector3d(0.1, -0.2, 0.15));
+    Vector3d p_I0inG(1.0, 0.5, 0.0);
+    Matrix3d R_GtoI1 = ov_core::exp_so3(Vector3d(0.05, -0.15, 0.3));
+    Vector3d p_I1inG(2.0, 1.0, 0.0);
+    Matrix3d R_ItoO = ov_core::exp_so3(Vector3d(0.0, 0.0, 0.2));
+    Vector3d p_IinO(0.1, 0.0, -0.2);
+
+    Vector3d w0(0.01, 0.02, 0.1), v0(0.5, 0.1, 0.0);
+    Vector3d w1(0.02, -0.01, 0.05), v1(0.6, -0.1, 0.0);
+
+    // Zero-residual nominal 3D measurement.
+    Vector3d pOinI = -R_ItoO.transpose() * p_IinO;
+    Matrix3d R_3D = R_ItoO * R_GtoI1 * R_GtoI0.transpose() * R_ItoO.transpose();
+    Vector3d p_3D = R_ItoO * R_GtoI0 * (p_I1inG + R_GtoI1.transpose() * pOinI - p_I0inG - R_GtoI0.transpose() * pOinI);
+
+    const auto [H_poses, H_ext] = UpdaterWheel::ComputeJacobians3D(R_GtoI0, p_I0inG, R_GtoI1, p_I1inG, R_ItoO, p_IinO);
+    Eigen::Matrix<double, 6, 1> H_dt = UpdaterWheel::ComputeTimeOffsetJacobian3D(H_poses, w0, v0, w1, v1);
+
+    Matrix3d R0p = ov_core::exp_so3(w0 * eps) * R_GtoI0;
+    Vector3d p0p = p_I0inG - v0 * eps;
+    Matrix3d R1p = ov_core::exp_so3(w1 * eps) * R_GtoI1;
+    Vector3d p1p = p_I1inG - v1 * eps;
+
+    Matrix3d R0m = ov_core::exp_so3(-w0 * eps) * R_GtoI0;
+    Vector3d p0m = p_I0inG + v0 * eps;
+    Matrix3d R1m = ov_core::exp_so3(-w1 * eps) * R_GtoI1;
+    Vector3d p1m = p_I1inG + v1 * eps;
+
+    Eigen::Matrix<double, 6, 1> res_plus = UpdaterWheel::ComputeResidual3D(R0p, p0p, R1p, p1p, R_ItoO, p_IinO, R_3D, p_3D);
+    Eigen::Matrix<double, 6, 1> res_minus = UpdaterWheel::ComputeResidual3D(R0m, p0m, R1m, p1m, R_ItoO, p_IinO, R_3D, p_3D);
+    Eigen::Matrix<double, 6, 1> H_dt_numerical = (res_plus - res_minus) / (2.0 * eps);
+
+    for (int i = 0; i < 6; i++) {
+        EXPECT_NEAR(H_dt(i), H_dt_numerical(i), tol)
+            << "3D H_dt mismatch at row=" << i;
+    }
+}


### PR DESCRIPTION
# Verify wheel Jacobians via unit tests (FD check, 4-PR campaign)

| # | Scope | Status |
|---|---|---|
| 1/4 | ComputeResidual2D + ComputeJacobians2D, SO(3) Jr fix, test_UpdaterWheel2D | shipped [#76] |
| 2/4 | ComputeResidual3D + ComputeJacobians3D, test_UpdaterWheel3D | shipped [#79] |
| 3/4 | ComputeTimeOffsetJacobian2D/3D, test_UpdaterWheelDt | **THIS PR** |
| 4/4 | intrinsic preintegration Jacobians + unit test | next |

## Summary

Extracts ComputeTimeOffsetJacobian2D and ComputeTimeOffsetJacobian3D as public static methods, refactors the do_calib_dt blocks in compute_linear_system_2D/3D to call them, and adds test_UpdaterWheelDt.cpp verifying both via combined finite differences.

The time-offset Jacobian is d(res)/d(dt) = H_poses * [w; v; w; v] (chain rule: increasing dt shifts both clone poses backward in time by the IMU velocity). The FD test models this as exp_so3(w*eps)*R and p - v*eps for each clone, confirming the sign convention (cpis.w = body-frame angular velocity, cpis.v = global-frame linear velocity).

No behavior change.

## Verification

WheelTimeOffset2D.AnalyticalMatchesNumerical: PASSED
WheelTimeOffset3D.AnalyticalMatchesNumerical: PASSED

## Chain

Chains off PR 2/4 (feat/unit-test-wheel-jacobian-3d -> #79).
Next in chain: PR 4/4 -- intrinsic preintegration Jacobians + unit test.