### PR TITLE
wheel: replace the type strings with an enum

### DIFF
--- a/mins/src/core/SystemManager.cpp
+++ b/mins/src/core/SystemManager.cpp
@@ -487,7 +487,7 @@ void SystemManager::print_status() {
   if (w_op->enabled)
   {
 
-    if (w_op->type != "Rover" && up_whl->t_hist.size() > 2)
+    if (up_whl->t_hist.size() > 2)
       PRINT2(" WHL %.1f", (up_whl->t_hist.size() - 1) / (up_whl->t_hist.back() - up_whl->t_hist.front()));
   }
 

--- a/mins/src/init/imu_wheel/IW_Initializer.cpp
+++ b/mins/src/init/imu_wheel/IW_Initializer.cpp
@@ -147,18 +147,19 @@ bool IW_Initializer::get_IMU_Wheel_data(vector<ImuData> &imu_data, vector<pair<d
   for (auto wheel : wheel_raw_data) {
     // compute the angular velocity at the odometry frame
     Vector3d w_OinO, v_OinO;
-    if (op->wheel_type == "Wheel2DAng" || op->wheel_type == "Wheel3DAng") {
+    switch (ModalityOf(op->wheel_type)) {
+    case WheelModality::Angular:
       w_OinO << 0, 0, (wheel.m2 * rr - wheel.m1 * rl) / base_length;
       v_OinO << (wheel.m2 * rr + wheel.m1 * rl) / 2, 0, 0;
-    } else if (op->wheel_type == "Wheel2DLin" || op->wheel_type == "Wheel3DLin") {
+      break;
+    case WheelModality::Linear:
       w_OinO << 0, 0, (wheel.m2 - wheel.m1) / base_length;
       v_OinO << (wheel.m2 + wheel.m1) / 2, 0, 0;
-    } else if (op->wheel_type == "Wheel2DCen" || op->wheel_type == "Wheel3DCen") {
+      break;
+    case WheelModality::Centered:
       w_OinO << 0, 0, wheel.m1;
       v_OinO << wheel.m2, 0, 0;
-    } else {
-      PRINT4("Wrong wheel type selected!");
-      exit(EXIT_FAILURE);
+      break;
     }
 
     // append the velocities

--- a/mins/src/init/imu_wheel/IW_Initializer.h
+++ b/mins/src/init/imu_wheel/IW_Initializer.h
@@ -21,6 +21,7 @@
 #ifndef MINS_IW_INITIALIZER_H
 #define MINS_IW_INITIALIZER_H
 
+#include "update/wheel/WheelTypes.h"
 #include <Eigen/Eigen>
 #include <memory>
 #include <vector>
@@ -49,7 +50,7 @@ public:
     shared_ptr<ov_type::PoseJPL> wheel_extrinsic;
     shared_ptr<ov_type::Vec> wheel_dt;
     shared_ptr<ov_type::Vec> wheel_intrinsic;
-    string wheel_type;
+    WheelType wheel_type = WheelType::Wheel2DAng;
     double threshold;
     Vector3d gravity;
     bool imu_gravity_aligned;

--- a/mins/src/options/OptionsWheel.cpp
+++ b/mins/src/options/OptionsWheel.cpp
@@ -81,15 +81,16 @@ void mins::OptionsWheel::load(const std::shared_ptr<ov_core::YamlParser> &parser
     intr << I[0], I[1], I[2];
     intrinsics = intr;
 
-    parser->parse_external(f, "wheel", "type", type);
-    if (type != "Wheel2DAng" && type != "Wheel2DLin" && type != "Wheel2DCen" && type != "Wheel3DAng" && type != "Wheel3DLin" && type != "Wheel3DCen") {
-      PRINT4(RED "%s is not a supported type of wheel.\n" RESET, type.c_str());
+    std::string type_name;
+    parser->parse_external(f, "wheel", "type", type_name);
+    if (!ParseWheelType(type_name, type)) {
+      PRINT4(RED "%s is not a supported type of wheel.\n" RESET, type_name.c_str());
       PRINT4(RED "Available: Wheel2DAng, Wheel2DLin, Wheel2DCen, Wheel3DAng, Wheel3DLin, Wheel3DCen\n" RESET);
       exit(EXIT_FAILURE);
     }
 
     // should disable intrinsic calibration if not using angular velocity of wheel
-    if (type != "Wheel2DAng" && type != "Wheel3DAng") {
+    if (ModalityOf(type) != WheelModality::Angular) {
       do_calib_int = false;
     }
   }
@@ -112,7 +113,7 @@ void mins::OptionsWheel::print() {
   PRINT1("\t- init_cov_in_b: %.6f\n", init_cov_in_b);
   PRINT1("\t- init_cov_in_r: %.6f\n", init_cov_in_r);
   PRINT1("\t- init_cov_in_r: %.6f\n", init_cov_in_r);
-  PRINT1("\t- WheelType: %s\n", type.c_str());
+  PRINT1("\t- WheelType: %s\n", ToString(type));
   PRINT1("\t- timeoffset: %6.3f\n", dt);
   PRINT1("\t- T_imu_wheel:\n");
   Eigen::Matrix3d R = ov_core::quat_2_Rot(extrinsics.head(4)).transpose();

--- a/mins/src/options/OptionsWheel.h
+++ b/mins/src/options/OptionsWheel.h
@@ -21,6 +21,7 @@
 #ifndef MINS_OPTIONSWHEEL_H
 #define MINS_OPTIONSWHEEL_H
 
+#include "update/wheel/WheelTypes.h"
 #include <Eigen/Eigen>
 #include <memory>
 #include <vector>
@@ -47,8 +48,8 @@ struct OptionsWheel {
 
   vector<string> sub_topics = {"front_left_wheel_joint", "front_right_wheel_joint", "rear_left_wheel_joint", "rear_right_wheel_joint"};
 
-  /// Type of the wheel
-  string type;
+  /// Measurement model of the wheel, resolved from the config yaml name
+  WheelType type = WheelType::Wheel2DAng;
 
   /// Noise settings for the measurements (angular/linear velocities & planar motion constraint)
   double noise_w = 0.005;

--- a/mins/src/sim/Simulator.cpp
+++ b/mins/src/sim/Simulator.cpp
@@ -680,7 +680,8 @@ bool Simulator::get_next_wheel(WheelData &wheel) {
   double b = op->sim->est_true->wheel->intrinsics(2);
 
   // Now, formulate measurements depend on what type of measurement we want
-  if (op->sim->est_true->wheel->type == "Wheel2DAng" || op->sim->est_true->wheel->type == "Wheel3DAng") {
+  switch (ModalityOf(op->sim->est_true->wheel->type)) {
+  case WheelModality::Angular: {
     // compute each wheels angular velocity
     double wl = (2 * v - b * w) / 2 / rl;
     double wr = (2 * v + b * w) / 2 / rr;
@@ -690,7 +691,9 @@ bool Simulator::get_next_wheel(WheelData &wheel) {
     }
     wheel.m1 = wl;
     wheel.m2 = wr;
-  } else if (op->sim->est_true->wheel->type == "Wheel2DLin" || op->sim->est_true->wheel->type == "Wheel3DLin") {
+    break;
+  }
+  case WheelModality::Linear: {
     // compute each wheels linear velocity
     double vl = (2 * v - b * w) / 2;
     double vr = (2 * v + b * w) / 2;
@@ -700,19 +703,19 @@ bool Simulator::get_next_wheel(WheelData &wheel) {
     }
     wheel.m1 = vl;
     wheel.m2 = vr;
-  } else if (op->sim->est_true->wheel->type == "Wheel2DCen" || op->sim->est_true->wheel->type == "Wheel3DCen") {
+    break;
+  }
+  case WheelModality::Centered:
     if (!op->sim->remove_noise) {
       v += op->sim->est_true->wheel->noise_v / sqrt(dt) * noise(seed_wheel);
       w += op->sim->est_true->wheel->noise_w / sqrt(dt) * noise(seed_wheel);
     }
     wheel.m1 = w;
     wheel.m2 = v;
-  } else {
-    PRINT4("No valid wheel measurement type selected\n");
-    exit(EXIT_FAILURE);
+    break;
   }
   // pass success
-  PRINT1("[SIM] Wheel measurement: %.3f|%s|%.3f,%.3f\n", wheel.time, op->sim->est_true->wheel->type.c_str(), wheel.m1, wheel.m2);
+  PRINT1("[SIM] Wheel measurement: %.3f|%s|%.3f,%.3f\n", wheel.time, ToString(op->sim->est_true->wheel->type), wheel.m1, wheel.m2);
   return true;
 }
 

--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -109,7 +109,7 @@ bool UpdaterWheel::update(double time0, double time1) {
   for (size_t i = 0; i < data_vec.size() - 1; i++) {
     double dt = data_vec[i + 1].time - data_vec[i].time;
     // Perform 3D integration
-    if (state->op->wheel->type == "Wheel3DAng" || state->op->wheel->type == "Wheel3DLin" || state->op->wheel->type == "Wheel3DCen") {
+    if (IsWheel3D(state->op->wheel->type)) {
       if (state->op->wheel->do_calib_int)
         preintegration_intrinsics_3D(dt, data_vec[i]);
       preintegration_3D(dt, data_vec[i], data_vec[i + 1]);
@@ -125,7 +125,7 @@ bool UpdaterWheel::update(double time0, double time1) {
   MatrixXd H;
   VectorXd res;
   vector<shared_ptr<ov_type::Type>> x_order;
-  if (state->op->wheel->type == "Wheel3DAng" || state->op->wheel->type == "Wheel3DLin" || state->op->wheel->type == "Wheel3DCen")
+  if (IsWheel3D(state->op->wheel->type))
     compute_linear_system_3D(H, res, time0, time1);
   else
     compute_linear_system_2D(H, res, time0, time1);
@@ -141,7 +141,7 @@ bool UpdaterWheel::update(double time0, double time1) {
     x_order.push_back(state->wheel_intrinsic);
 
   // Perform update
-  if (state->op->wheel->type == "Wheel3DAng" || state->op->wheel->type == "Wheel3DLin" || state->op->wheel->type == "Wheel3DCen") {
+  if (IsWheel3D(state->op->wheel->type)) {
     if (Chi->Chi2Check(state, x_order, H, res, Cov_3D))
       StateHelper::EKFUpdate(state, x_order, H, res, Cov_3D, "WHEEL");
   } else {
@@ -508,25 +508,26 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
   double b = state->wheel_intrinsic->value()(2);
 
   // compute the velocities at the odometry frame
-  double w1, w2, v1, v2;
-  if (state->op->wheel->type == "Wheel2DAng") {
+  double w1 = 0, w2 = 0, v1 = 0, v2 = 0;
+  switch (ModalityOf(state->op->wheel->type)) {
+  case WheelModality::Angular:
     w1 = (data1.m2 * rr - data1.m1 * rl) / b;
     v1 = (data1.m2 * rr + data1.m1 * rl) / 2;
     w2 = (data2.m2 * rr - data2.m1 * rl) / b;
     v2 = (data2.m2 * rr + data2.m1 * rl) / 2;
-  } else if (state->op->wheel->type == "Wheel2DLin") {
+    break;
+  case WheelModality::Linear:
     w1 = (data1.m2 - data1.m1) / b;
     v1 = (data1.m2 + data1.m1) / 2;
     w2 = (data2.m2 - data2.m1) / b;
     v2 = (data2.m2 + data2.m1) / 2;
-  } else if (state->op->wheel->type == "Wheel2DCen") {
+    break;
+  case WheelModality::Centered:
     w1 = data1.m1;
     v1 = data1.m2;
     w2 = data2.m1;
     v2 = data2.m2;
-  } else {
-    PRINT4("Wrong wheel type selected!");
-    exit(EXIT_FAILURE);
+    break;
   }
 
   // =========================================================
@@ -576,21 +577,25 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
 
   // Compute noise Jacobians respect to measurements
   Matrix<double, 1, 2> Hwn, Hvn;
-  if (state->op->wheel->type == "Wheel2DAng") {
+  switch (ModalityOf(state->op->wheel->type)) {
+  case WheelModality::Angular:
     Hwn(0, 0) = rl / b;
     Hwn(0, 1) = -rr / b;
     Hvn(0, 0) = -rl / 2;
     Hvn(0, 1) = -rr / 2;
-  } else if (state->op->wheel->type == "Wheel2DLin") {
+    break;
+  case WheelModality::Linear:
     Hwn(0, 0) = 1.0 / b;
     Hwn(0, 1) = -1.0 / b;
     Hvn(0, 0) = -1.0 / 2;
     Hvn(0, 1) = -1.0 / 2;
-  } else if (state->op->wheel->type == "Wheel2DCen") {
+    break;
+  case WheelModality::Centered:
     Hwn(0, 0) = 1;
     Hwn(0, 1) = 0;
     Hvn(0, 0) = 0;
     Hvn(0, 1) = 1;
+    break;
   }
 
   // Compute Jacobians respect to state preintegrated state and the measurement
@@ -625,13 +630,17 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
 
   // Compute Measurement covariance
   Matrix2d Q = Matrix2d::Zero();
-  if (state->op->wheel->type == "Wheel2DAng") {
+  switch (ModalityOf(state->op->wheel->type)) {
+  case WheelModality::Angular:
     Q = pow(state->op->wheel->noise_w, 2) / dt * Matrix2d::Identity();
-  } else if (state->op->wheel->type == "Wheel2DLin") {
+    break;
+  case WheelModality::Linear:
     Q = pow(state->op->wheel->noise_v, 2) / dt * Matrix2d::Identity();
-  } else if (state->op->wheel->type == "Wheel2DCen") {
+    break;
+  case WheelModality::Centered:
     Q(0, 0) = pow(state->op->wheel->noise_w, 2) / dt;
     Q(1, 1) = pow(state->op->wheel->noise_v, 2) / dt;
+    break;
   }
 
   // integrate noise covarinace
@@ -662,24 +671,25 @@ void UpdaterWheel::preintegration_3D(double dt, const WheelData &data1, const Wh
 
   // compute the velocities at the odometry frame
   Vector3d w_hat1, v_hat1, w_hat2, v_hat2;
-  if (state->op->wheel->type == "Wheel3DAng") {
+  switch (ModalityOf(state->op->wheel->type)) {
+  case WheelModality::Angular:
     w_hat1 << 0, 0, (data1.m2 * rr - data1.m1 * rl) / b;
     v_hat1 << (data1.m2 * rr + data1.m1 * rl) / 2, 0, 0;
     w_hat2 << 0, 0, (data2.m2 * rr - data2.m1 * rl) / b;
     v_hat2 << (data2.m2 * rr + data2.m1 * rl) / 2, 0, 0;
-  } else if (state->op->wheel->type == "Wheel3DLin") {
+    break;
+  case WheelModality::Linear:
     w_hat1 << 0, 0, (data1.m2 - data1.m1) / b;
     v_hat1 << (data1.m2 + data1.m1) / 2, 0, 0;
     w_hat2 << 0, 0, (data2.m2 - data2.m1) / b;
     v_hat2 << (data2.m2 + data2.m1) / 2, 0, 0;
-  } else if (state->op->wheel->type == "Wheel3DCen") {
+    break;
+  case WheelModality::Centered:
     w_hat1 << 0, 0, data1.m1;
     v_hat1 << data1.m2, 0, 0;
     w_hat2 << 0, 0, data2.m1;
     v_hat2 << data2.m2, 0, 0;
-  } else {
-    PRINT4("Wrong wheel type selected!");
-    exit(EXIT_FAILURE);
+    break;
   }
 
   // =========================================================
@@ -735,30 +745,31 @@ void UpdaterWheel::preintegration_3D(double dt, const WheelData &data1, const Wh
 
   // compute measurement noise
   Matrix<double, 6, 6> Q = Matrix<double, 6, 6>::Zero();
-  if (state->op->wheel->type == "Wheel3DAng") {
+  switch (ModalityOf(state->op->wheel->type)) {
+  case WheelModality::Angular:
     Q.block(0, 0, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(1, 1, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(2, 2, 1, 1) << pow(state->op->wheel->noise_w, 2) / dt;
     Q.block(3, 3, 1, 1) << pow(state->op->wheel->noise_v, 2) / dt;
     Q.block(4, 4, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(5, 5, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-  } else if (state->op->wheel->type == "Wheel3DLin") {
+    break;
+  case WheelModality::Linear:
     Q.block(0, 0, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(1, 1, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(2, 2, 1, 1) << 2 * pow(state->op->wheel->noise_v, 2) / b / b / dt;
     Q.block(3, 3, 1, 1) << pow(state->op->wheel->noise_v, 2) / 2 / dt;
     Q.block(4, 4, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(5, 5, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-  } else if (state->op->wheel->type == "Wheel3DCen") {
+    break;
+  case WheelModality::Centered:
     Q.block(0, 0, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(1, 1, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(2, 2, 1, 1) << pow(state->op->wheel->noise_w, 2) / dt;
     Q.block(3, 3, 1, 1) << pow(state->op->wheel->noise_v, 2) / dt;
     Q.block(4, 4, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
     Q.block(5, 5, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-  } else {
-    PRINT4(RED "[MINS] Invalid wheel type provided.\n" RESET);
-    exit(EXIT_FAILURE);
+    break;
   }
 
   // Compute the Jacobians with respect to the current preintegrated measurements

--- a/mins/src/update/wheel/WheelTypes.h
+++ b/mins/src/update/wheel/WheelTypes.h
@@ -21,15 +21,96 @@
 #ifndef MINS_WHEELTYPES_H
 #define MINS_WHEELTYPES_H
 
+#include <string>
+
 namespace mins {
 
-/// Types of wheel measurements supported
-/// Wheel2DAng: left/right wheel angular velocities. Additionally supports intrinsic (left/right wheel radii & base length) calibration
-/// Wheel2DLin: left/right wheel linear velocities.
-/// Wheel2DCen: angular/linear wheel velocities of the wheel odometry frame.
-/// Wheel3DAng: left/right wheel angular velocities + planar motion constraint. Additionally supports intrinsic calibration
-/// Wheel3DLin: left/right wheel linear velocities + planar motion constraint.
-/// Wheel3DCen: angular/linear wheel velocities of the wheel odometry frame + planar motion constraint.
+/// What the two wheel readings actually measure.
+enum class WheelModality {
+  Angular,  ///< Left and right wheel angular velocities. The only modality supporting intrinsic calibration.
+  Linear,   ///< Left and right wheel linear velocities.
+  Centered, ///< Angular and linear velocity of the wheel odometry frame itself.
+};
+
+/// Wheel measurement model. Each 3D variant adds a planar motion constraint to its 2D counterpart.
+enum class WheelType {
+  Wheel2DAng,
+  Wheel2DLin,
+  Wheel2DCen,
+  Wheel3DAng,
+  Wheel3DLin,
+  Wheel3DCen,
+};
+
+/**
+ * \brief Name of a wheel type, spelled as it appears in the config yaml.
+ * \param[in] type Wheel type to name.
+ * \return Type name, or an empty string for an out-of-range value.
+ */
+inline const char *ToString(WheelType type) {
+  switch (type) {
+  case WheelType::Wheel2DAng:
+    return "Wheel2DAng";
+  case WheelType::Wheel2DLin:
+    return "Wheel2DLin";
+  case WheelType::Wheel2DCen:
+    return "Wheel2DCen";
+  case WheelType::Wheel3DAng:
+    return "Wheel3DAng";
+  case WheelType::Wheel3DLin:
+    return "Wheel3DLin";
+  case WheelType::Wheel3DCen:
+    return "Wheel3DCen";
+  }
+  return "";
+}
+
+/// Every supported wheel type, in declaration order.
+static constexpr WheelType ALL_WHEEL_TYPES[] = {WheelType::Wheel2DAng, WheelType::Wheel2DLin, WheelType::Wheel2DCen,
+                                                WheelType::Wheel3DAng, WheelType::Wheel3DLin, WheelType::Wheel3DCen};
+
+/**
+ * \brief Resolve a config yaml type name to a wheel type.
+ * \param[in] name Type name to resolve.
+ * \param[out] type Resolved type, left untouched when the name is not supported.
+ * \return True when the name names a supported type.
+ */
+inline bool ParseWheelType(const std::string &name, WheelType &type) {
+  for (WheelType candidate : ALL_WHEEL_TYPES) {
+    if (name == ToString(candidate)) {
+      type = candidate;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * \brief Whether a type carries the planar motion constraint.
+ * \param[in] type Wheel type to test.
+ * \return True for the 3D variants.
+ */
+inline bool IsWheel3D(WheelType type) { return type == WheelType::Wheel3DAng || type == WheelType::Wheel3DLin || type == WheelType::Wheel3DCen; }
+
+/**
+ * \brief What the readings of a given type measure, ignoring its 2D/3D flavor.
+ * \param[in] type Wheel type to inspect.
+ * \return Modality of the type.
+ */
+inline WheelModality ModalityOf(WheelType type) {
+  switch (type) {
+  case WheelType::Wheel2DAng:
+  case WheelType::Wheel3DAng:
+    return WheelModality::Angular;
+  case WheelType::Wheel2DLin:
+  case WheelType::Wheel3DLin:
+    return WheelModality::Linear;
+  case WheelType::Wheel2DCen:
+  case WheelType::Wheel3DCen:
+    return WheelModality::Centered;
+  }
+  return WheelModality::Angular;
+}
 
 struct WheelData {
 


### PR DESCRIPTION
# Modernize the wheel updater: validated type enum, Jacobians in their own file, no duplicated math, no `friend`s. No behavior change.

| # | Scope | Status |
|---|---|---|
| 1/5 | Cleanup: mangled doxygen escapes, `WheelData` params by-value to const-ref, ternary-as-statement, magic numbers | shipped |
| 2/5 | Wheel type `string` to enum, resolved once in `OptionsWheel::load` | **THIS PR** |
| 3/5 | Move the 9 stateless `Compute*`/`Accumulate*` statics into `namespace mins::wheel` in `WheelJacobians.h/.cpp` | upcoming |
| 4/5 | Dedup the L'Hopital block shared by `preintegration_2D` and `AccumulateIntrinsicJacobians2D`; add a preintegration round-trip test | upcoming |
| 5/5 | Drop `friend class Initializer` / `friend class IW_Initializer` | upcoming |

## Summary

`WheelType` and `WheelModality` enums land in `WheelTypes.h`, and the config yaml
name is resolved to a `WheelType` once in `OptionsWheel::load`.

That removes all 21 `type == "WheelXDYyy"` compares: three collapse to
`IsWheel3D()`, five become `switch (ModalityOf(...))` in `UpdaterWheel.cpp`, and
`IW_Initializer` plus `Simulator` — which only ever cared about the modality, not
the 2D/3D flavor — get the same treatment. Both
`PRINT4("Wrong wheel type selected!"); exit(EXIT_FAILURE);` branches in the
preintegration path are gone: the switches are exhaustive, so `-Wswitch` flags a
future enumerator at compile time instead of aborting the filter at runtime.

Two things the compiler found:

- `SystemManager::print_status` guarded on `w_op->type != "Rover"`. `Rover` was
  never one of the six supported types, so that compare was always true. Dropped.
- `IW_Initializer_Options::wheel_type` was a `string` fed from
  `state->op->wheel->type`, so it flips with it.

## Verification

`catkin build mins` clean, `ctest` 5/5 pass.

Worth flagging for review: the five existing tests never set `op->wheel->type`,
so they exercise none of the rewritten dispatch. The mapping is branch-for-branch
identical, but the real check is a sim run, not ctest.

## Chain

Chains off PR 1/5.
Next: PR 3/5 — the stateless `Compute*` statics move out of the class into
`namespace mins::wheel` in their own file.
