### PR TITLE
wheel: share the 2D preintegration partials

### DIFF
--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -393,6 +393,28 @@ Matrix<double, 6, 1> UpdaterWheel::ComputeTimeOffsetJacobian3D(const MatrixXd &H
   return H_poses * vel;
 }
 
+PreintegrationPartials2D UpdaterWheel::ComputePreintegrationPartials2D(double dt, double w, double v,
+                                                                      double th) {
+  PreintegrationPartials2D partials;
+  partials.h_thw = dt;
+  if (abs(w) < SMALL_ANGULAR_RATE) {
+    partials.h_xth = v * sin(th) * dt;
+    partials.h_yth = v * cos(th) * dt;
+    partials.h_xw = v * sin(th) * dt * dt / 2;
+    partials.h_yw = v * cos(th) * dt * dt / 2;
+    partials.h_xv = cos(th) * dt;
+    partials.h_yv = -sin(th) * dt;
+    return partials;
+  }
+  partials.h_xth = (v * (cos(th - w * dt) - cos(th))) / w;
+  partials.h_yth = -(v * (sin(th - w * dt) - sin(th))) / w;
+  partials.h_xw = (v * (sin(th - w * dt) - sin(th))) / w / w + (v * cos(th - w * dt) * dt) / w;
+  partials.h_yw = (v * (cos(th - w * dt) - cos(th))) / w / w - (v * sin(th - w * dt) * dt) / w;
+  partials.h_xv = -(sin(th - w * dt) - sin(th)) / w;
+  partials.h_yv = -(cos(th - w * dt) - cos(th)) / w;
+  return partials;
+}
+
 void UpdaterWheel::AccumulateIntrinsicJacobians2D(double dt, double w_l, double w_r, double th,
                                                    double rl, double rr, double b,
                                                    Matrix<double, 1, 3> &dth_di,
@@ -409,26 +431,11 @@ void UpdaterWheel::AccumulateIntrinsicJacobians2D(double dt, double w_l, double 
   Hvx(0, 0) = w_l / 2;
   Hvx(0, 1) = w_r / 2;
 
-  double h_thw = dt;
-  double h_xth = (v * (cos(th - w * dt) - cos(th))) / w;
-  double h_yth = -(v * (sin(th - w * dt) - sin(th))) / w;
-  double h_xw = (v * (sin(th - w * dt) - sin(th))) / w / w + (v * cos(th - w * dt) * dt) / w;
-  double h_yw = (v * (cos(th - w * dt) - cos(th))) / w / w - (v * sin(th - w * dt) * dt) / w;
-  double h_xv = -(sin(th - w * dt) - sin(th)) / w;
-  double h_yv = -(cos(th - w * dt) - cos(th)) / w;
+  const PreintegrationPartials2D partials = ComputePreintegrationPartials2D(dt, w, v, th);
 
-  if (abs(w) < SMALL_ANGULAR_RATE) {
-    h_xth = v * sin(th) * dt;
-    h_yth = v * cos(th) * dt;
-    h_xw = v * sin(th) * dt * dt / 2;
-    h_yw = v * cos(th) * dt * dt / 2;
-    h_xv = cos(th) * dt;
-    h_yv = -sin(th) * dt;
-  }
-
-  dx_di = dx_di + h_xth * dth_di + h_xw * Hwx + h_xv * Hvx;
-  dy_di = dy_di + h_yth * dth_di + h_yw * Hwx + h_yv * Hvx;
-  dth_di = dth_di + h_thw * Hwx;
+  dx_di = dx_di + partials.h_xth * dth_di + partials.h_xw * Hwx + partials.h_xv * Hvx;
+  dy_di = dy_di + partials.h_yth * dth_di + partials.h_yw * Hwx + partials.h_yv * Hvx;
+  dth_di = dth_di + partials.h_thw * Hwx;
 }
 
 void UpdaterWheel::AccumulateIntrinsicJacobians3D(double dt, double w_l, double w_r,
@@ -599,34 +606,18 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
   }
 
   // Compute Jacobians respect to state preintegrated state and the measurement
-  double h_thw = dt;
-  double h_xth = (v1 * (cos(th_2D - w1 * dt) - cos(th_2D))) / w1;
-  double h_yth = -(v1 * (sin(th_2D - w1 * dt) - sin(th_2D))) / w1;
-  double h_xw = (v1 * (sin(th_2D - w1 * dt) - sin(th_2D))) / w1 / w1 + (v1 * cos(th_2D - w1 * dt) * dt) / w1;
-  double h_yw = (v1 * (cos(th_2D - w1 * dt) - cos(th_2D))) / w1 / w1 - (v1 * sin(th_2D - w1 * dt) * dt) / w1;
-  double h_xv = -(sin(th_2D - w1 * dt) - sin(th_2D)) / w1;
-  double h_yv = -(cos(th_2D - w1 * dt) - cos(th_2D)) / w1;
-
-  // In case w is too small, apply L'Hopital rule
-  if (abs(w1) < SMALL_ANGULAR_RATE) {
-    h_xth = v1 * sin(th_2D) * dt;
-    h_yth = v1 * cos(th_2D) * dt;
-    h_xw = v1 * sin(th_2D) * dt * dt / 2;
-    h_yw = v1 * cos(th_2D) * dt * dt / 2;
-    h_xv = cos(th_2D) * dt;
-    h_yv = -sin(th_2D) * dt;
-  }
+  const PreintegrationPartials2D partials = ComputePreintegrationPartials2D(dt, w1, v1, th_2D);
 
   // Compute the Jacobians with respect to the current preintegrated states
   Matrix3d Phi_tr = Matrix3d::Identity();
-  Phi_tr(1, 0) = h_xth;
-  Phi_tr(2, 0) = h_yth;
+  Phi_tr(1, 0) = partials.h_xth;
+  Phi_tr(2, 0) = partials.h_yth;
 
   // compute noise Jacobian
   Matrix<double, 3, 2> Phi_ns = Matrix<double, 3, 2>::Zero();
-  Phi_ns.block(0, 0, 1, 2) = h_thw * Hwn;
-  Phi_ns.block(1, 0, 1, 2) = h_xw * Hwn + h_xv * Hvn;
-  Phi_ns.block(2, 0, 1, 2) = h_yw * Hwn + h_yv * Hvn;
+  Phi_ns.block(0, 0, 1, 2) = partials.h_thw * Hwn;
+  Phi_ns.block(1, 0, 1, 2) = partials.h_xw * Hwn + partials.h_xv * Hvn;
+  Phi_ns.block(2, 0, 1, 2) = partials.h_yw * Hwn + partials.h_yv * Hvn;
 
   // Compute Measurement covariance
   Matrix2d Q = Matrix2d::Zero();

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -31,6 +31,22 @@ namespace mins {
 class State;
 class UpdaterStatistics;
 struct WheelData;
+/**
+ * \brief Partial derivatives of one 2D preintegration step, shared by the state and intrinsic Jacobians.
+ *
+ * Signs follow the error-state convention of the updater, so each term is the negated
+ * derivative of the closed-form (x, y) update.
+ */
+struct PreintegrationPartials2D {
+  double h_thw; ///< d(theta)/d(w).
+  double h_xth; ///< d(x)/d(theta).
+  double h_yth; ///< d(y)/d(theta).
+  double h_xw;  ///< d(x)/d(w).
+  double h_yw;  ///< d(y)/d(w).
+  double h_xv;  ///< d(x)/d(v).
+  double h_yv;  ///< d(y)/d(v).
+};
+
 class UpdaterWheel {
 
 public:
@@ -153,6 +169,20 @@ public:
   static Eigen::Matrix<double, 6, 1> ComputeTimeOffsetJacobian3D(const Eigen::MatrixXd &H_poses,
                                                                    const Eigen::Vector3d &w0, const Eigen::Vector3d &v0,
                                                                    const Eigen::Vector3d &w1, const Eigen::Vector3d &v1);
+
+  /**
+   * \brief Compute the partial derivatives of one 2D preintegration step.
+   *
+   * Falls back to the L'Hopital limit of each term when the angular rate is near zero.
+   *
+   * \param[in] dt Time interval for this step.
+   * \param[in] w Angular rate of the odometry frame.
+   * \param[in] v Forward velocity of the odometry frame.
+   * \param[in] th Accumulated heading angle before this step.
+   * \return Partial derivatives of this step.
+   */
+  static PreintegrationPartials2D ComputePreintegrationPartials2D(double dt, double w, double v,
+                                                                  double th);
 
   /**
    * \brief Accumulate one step of intrinsic Jacobians for the 2D wheel odometry preintegration.


### PR DESCRIPTION
# Modernize the wheel updater: enum-based dispatch, no duplicated formulas. No behavior change.

| # | Scope | Status |
|---|---|---|
| 1/4 | Cleanup: fix mangled doxygen, `const WheelData` by-value to const-ref, ternary-as-statement, name magic numbers | merged #87 |
| 2/4 | Wheel type `string` to enum, parsed and validated once in `OptionsWheel::load` | merged #88 |
| 3/4 | Dedup the 2D preintegration partials | **THIS PR** |
| 4/4 | Drop `friend class Initializer` / `friend class IW_Initializer` | open #91 |

A fifth PR (#89) moved the stateless Jacobian math into its own `WheelJacobians.h/.cpp`.
It is closed: the testability argument behind it did not hold, since `UpdaterWheel.h`
already forward-declared its heavy dependencies. This chain is rebased onto master
without it.

## Summary

`preintegration_2D` and `AccumulateIntrinsicJacobians2D` each carried the same seven
partial derivatives of the closed-form 2D odometry update, plus the same small-angle
fallback, copied line for line. Both now call `ComputePreintegrationPartials2D`, which
returns them in a `PreintegrationPartials2D` struct.

The small-angle branch returns early rather than computing all seven closed-form terms
and then overwriting six of them, so we no longer divide by a near-zero angular rate just
to discard the result. The outputs are identical either way.

The helper is a static on `UpdaterWheel`, next to the other `Compute*` / `Accumulate*`
statics that were already there.

## Verification

- `catkin build mins` clean, no new warnings.
- `ctest` 5/5 pass.
- The two call sites were diffed term by term against the originals; only the variable
  names changed.

## Chain

Chains off PR 2/4 (#88), which is merged, so the base is master.
Next in chain: PR 4/4 (#91) - drop the friend declarations.
