### PR TITLE
wheel: drop the friend declarations from UpdaterWheel

### DIFF
--- a/mins/src/init/Initializer.cpp
+++ b/mins/src/init/Initializer.cpp
@@ -48,6 +48,7 @@
 #include "update/gps/UpdaterGPS.h"
 #include "update/lidar/LidarHelper.h"
 #include "update/lidar/LidarTypes.h"
+#include "update/lidar/PointCloud.h"
 #include "update/lidar/UpdaterLidar.h"
 #include "update/lidar/ikd_Tree.h"
 #include "update/wheel/UpdaterWheel.h"
@@ -55,7 +56,6 @@
 #include "utils/Print_Logger.h"
 #include "utils/TimeChecker.h"
 #include "utils/dataset_reader.h"
-#include "update/lidar/PointCloud.h"
 using namespace std;
 using namespace Eigen;
 using namespace mins;
@@ -178,12 +178,8 @@ void Initializer::delete_old_measurements() {
 
     // wheel
     if (state->op->wheel->enabled) {
-      int del_whl = 0;
-      for (auto data = up_whl->data_stack.begin(); !up_whl->data_stack.empty() && (*data).time < old_time;) {
-        del_whl++;
-        data = up_whl->data_stack.erase(data);
-      }
-      del_whl > 0 ? PRINT1(YELLOW "[INIT]: Delete Wheel stack. Del: %d, Remain: %d\n" RESET, del_whl, up_whl->data_stack.size()) : void();
+      int del_whl = up_whl->cleanup_measurements(old_time);
+      del_whl > 0 ? PRINT1(YELLOW "[INIT]: Delete Wheel stack. Del: %d, Remain: %d\n" RESET, del_whl, up_whl->num_measurements()) : void();
     }
 
     // lidar

--- a/mins/src/init/imu_wheel/IW_Initializer.cpp
+++ b/mins/src/init/imu_wheel/IW_Initializer.cpp
@@ -110,16 +110,17 @@ bool IW_Initializer::initialization(Matrix<double, 17, 1> &imustate) {
 bool IW_Initializer::get_IMU_Wheel_data(vector<ImuData> &imu_data, vector<pair<double, VectorXd>> &wheel_data) {
 
   // do not perform initialization if we don't have enough data
-  if (imu_pp->imu_data.size() < 3 || wheel_up->data_stack.size() < 3) {
-    PRINT1(YELLOW "[IW-Init]: Waiting for collecting IMU(%d < 3) and wheel data(%d < 3).\n" RESET, imu_pp->imu_data.size(), wheel_up->data_stack.size());
+  double min_wheel_t, max_wheel_t;
+  if (imu_pp->imu_data.size() < 3 || !wheel_up->measurement_time_span(min_wheel_t, max_wheel_t)) {
+    PRINT1(YELLOW "[IW-Init]: Waiting for collecting IMU(%d < 3) and wheel data(%d < 3).\n" RESET, imu_pp->imu_data.size(), wheel_up->num_measurements());
     return false;
   }
 
   // get the min max times of imu and wheel data
   double min_imu_t = imu_pp->imu_data.at(1).timestamp;
   double max_imu_t = imu_pp->imu_data.at(imu_pp->imu_data.size() - 2).timestamp;
-  double min_wheel_t = wheel_up->data_stack.at(1).time + toff;                               // convert to IMU time
-  double max_wheel_t = wheel_up->data_stack.at(wheel_up->data_stack.size() - 2).time + toff; // convert to IMU time
+  min_wheel_t += toff; // convert to IMU time
+  max_wheel_t += toff; // convert to IMU time
 
   // find common time zone
   double min_t = max(min_imu_t, min_wheel_t);

--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -154,6 +154,26 @@ bool UpdaterWheel::update(double time0, double time1) {
   return true;
 }
 
+int UpdaterWheel::cleanup_measurements(double oldest_time) {
+  int count = 0;
+  for (auto data = data_stack.begin(); data != data_stack.end() && data->time < oldest_time;) {
+    count++;
+    data = data_stack.erase(data);
+  }
+  return count;
+}
+
+size_t UpdaterWheel::num_measurements() const { return data_stack.size(); }
+
+bool UpdaterWheel::measurement_time_span(double &min_time, double &max_time) const {
+  if (data_stack.size() < 3) {
+    return false;
+  }
+  min_time = data_stack.at(1).time;
+  max_time = data_stack.at(data_stack.size() - 2).time;
+  return true;
+}
+
 bool UpdaterWheel::select_wheel_data(double time0, double time1, vector<WheelData> &data_vec) {
   // Ensure we have some measurements in the first place!
   if (data_stack.empty()) {

--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -393,6 +393,28 @@ Matrix<double, 6, 1> UpdaterWheel::ComputeTimeOffsetJacobian3D(const MatrixXd &H
   return H_poses * vel;
 }
 
+PreintegrationPartials2D UpdaterWheel::ComputePreintegrationPartials2D(double dt, double w, double v,
+                                                                      double th) {
+  PreintegrationPartials2D partials;
+  partials.h_thw = dt;
+  if (abs(w) < SMALL_ANGULAR_RATE) {
+    partials.h_xth = v * sin(th) * dt;
+    partials.h_yth = v * cos(th) * dt;
+    partials.h_xw = v * sin(th) * dt * dt / 2;
+    partials.h_yw = v * cos(th) * dt * dt / 2;
+    partials.h_xv = cos(th) * dt;
+    partials.h_yv = -sin(th) * dt;
+    return partials;
+  }
+  partials.h_xth = (v * (cos(th - w * dt) - cos(th))) / w;
+  partials.h_yth = -(v * (sin(th - w * dt) - sin(th))) / w;
+  partials.h_xw = (v * (sin(th - w * dt) - sin(th))) / w / w + (v * cos(th - w * dt) * dt) / w;
+  partials.h_yw = (v * (cos(th - w * dt) - cos(th))) / w / w - (v * sin(th - w * dt) * dt) / w;
+  partials.h_xv = -(sin(th - w * dt) - sin(th)) / w;
+  partials.h_yv = -(cos(th - w * dt) - cos(th)) / w;
+  return partials;
+}
+
 void UpdaterWheel::AccumulateIntrinsicJacobians2D(double dt, double w_l, double w_r, double th,
                                                    double rl, double rr, double b,
                                                    Matrix<double, 1, 3> &dth_di,
@@ -409,26 +431,11 @@ void UpdaterWheel::AccumulateIntrinsicJacobians2D(double dt, double w_l, double 
   Hvx(0, 0) = w_l / 2;
   Hvx(0, 1) = w_r / 2;
 
-  double h_thw = dt;
-  double h_xth = (v * (cos(th - w * dt) - cos(th))) / w;
-  double h_yth = -(v * (sin(th - w * dt) - sin(th))) / w;
-  double h_xw = (v * (sin(th - w * dt) - sin(th))) / w / w + (v * cos(th - w * dt) * dt) / w;
-  double h_yw = (v * (cos(th - w * dt) - cos(th))) / w / w - (v * sin(th - w * dt) * dt) / w;
-  double h_xv = -(sin(th - w * dt) - sin(th)) / w;
-  double h_yv = -(cos(th - w * dt) - cos(th)) / w;
+  const PreintegrationPartials2D partials = ComputePreintegrationPartials2D(dt, w, v, th);
 
-  if (abs(w) < SMALL_ANGULAR_RATE) {
-    h_xth = v * sin(th) * dt;
-    h_yth = v * cos(th) * dt;
-    h_xw = v * sin(th) * dt * dt / 2;
-    h_yw = v * cos(th) * dt * dt / 2;
-    h_xv = cos(th) * dt;
-    h_yv = -sin(th) * dt;
-  }
-
-  dx_di = dx_di + h_xth * dth_di + h_xw * Hwx + h_xv * Hvx;
-  dy_di = dy_di + h_yth * dth_di + h_yw * Hwx + h_yv * Hvx;
-  dth_di = dth_di + h_thw * Hwx;
+  dx_di = dx_di + partials.h_xth * dth_di + partials.h_xw * Hwx + partials.h_xv * Hvx;
+  dy_di = dy_di + partials.h_yth * dth_di + partials.h_yw * Hwx + partials.h_yv * Hvx;
+  dth_di = dth_di + partials.h_thw * Hwx;
 }
 
 void UpdaterWheel::AccumulateIntrinsicJacobians3D(double dt, double w_l, double w_r,
@@ -599,34 +606,18 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
   }
 
   // Compute Jacobians respect to state preintegrated state and the measurement
-  double h_thw = dt;
-  double h_xth = (v1 * (cos(th_2D - w1 * dt) - cos(th_2D))) / w1;
-  double h_yth = -(v1 * (sin(th_2D - w1 * dt) - sin(th_2D))) / w1;
-  double h_xw = (v1 * (sin(th_2D - w1 * dt) - sin(th_2D))) / w1 / w1 + (v1 * cos(th_2D - w1 * dt) * dt) / w1;
-  double h_yw = (v1 * (cos(th_2D - w1 * dt) - cos(th_2D))) / w1 / w1 - (v1 * sin(th_2D - w1 * dt) * dt) / w1;
-  double h_xv = -(sin(th_2D - w1 * dt) - sin(th_2D)) / w1;
-  double h_yv = -(cos(th_2D - w1 * dt) - cos(th_2D)) / w1;
-
-  // In case w is too small, apply L'Hopital rule
-  if (abs(w1) < SMALL_ANGULAR_RATE) {
-    h_xth = v1 * sin(th_2D) * dt;
-    h_yth = v1 * cos(th_2D) * dt;
-    h_xw = v1 * sin(th_2D) * dt * dt / 2;
-    h_yw = v1 * cos(th_2D) * dt * dt / 2;
-    h_xv = cos(th_2D) * dt;
-    h_yv = -sin(th_2D) * dt;
-  }
+  const PreintegrationPartials2D partials = ComputePreintegrationPartials2D(dt, w1, v1, th_2D);
 
   // Compute the Jacobians with respect to the current preintegrated states
   Matrix3d Phi_tr = Matrix3d::Identity();
-  Phi_tr(1, 0) = h_xth;
-  Phi_tr(2, 0) = h_yth;
+  Phi_tr(1, 0) = partials.h_xth;
+  Phi_tr(2, 0) = partials.h_yth;
 
   // compute noise Jacobian
   Matrix<double, 3, 2> Phi_ns = Matrix<double, 3, 2>::Zero();
-  Phi_ns.block(0, 0, 1, 2) = h_thw * Hwn;
-  Phi_ns.block(1, 0, 1, 2) = h_xw * Hwn + h_xv * Hvn;
-  Phi_ns.block(2, 0, 1, 2) = h_yw * Hwn + h_yv * Hvn;
+  Phi_ns.block(0, 0, 1, 2) = partials.h_thw * Hwn;
+  Phi_ns.block(1, 0, 1, 2) = partials.h_xw * Hwn + partials.h_xv * Hvn;
+  Phi_ns.block(2, 0, 1, 2) = partials.h_yw * Hwn + partials.h_yv * Hvn;
 
   // Compute Measurement covariance
   Matrix2d Q = Matrix2d::Zero();

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -63,7 +63,8 @@ public:
    * @brief Collects a set of wheel measurements between time0 and time1
    * @param data_vec output as a set of wheel measurements
    * @param time0 start timestamp of the update
-   * @param state end timestamp of the update
+   * @param time1 end timestamp of the update
+   * @return false if the stack cannot cover the interval with at least two measurements
    */
   bool select_wheel_data(double time0, double time1, std::vector<WheelData> &data_vec);
 

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -273,9 +273,9 @@ public:
 private:
   /**
    * @brief Checks if we have enough clones and handover two last clone times to update
-   * @param state current state info
    * @param time0 start timestamp of the update
    * @param time1 end timestamp of the update
+   * @return false if the measurements or the clones cannot support the update
    */
   bool update(double time0, double time1);
 
@@ -289,13 +289,14 @@ private:
    * @param data1 wheel at begining of interpolation interval
    * @param data2 wheel at end of interpolation interval
    * @param timestamp Timestamp being interpolated to
+   * @return wheel measurement at the given timestamp
    */
   static WheelData interpolate_data(const WheelData &data1, const WheelData &data2, double timestamp);
 
   /**
    * @brief Compute 2D or 3D Jacobians of intrinsic parameters during preintegration
    * @param dt time interval between the preintegration steps
-   * @param WheelData wheel measurement of the current step
+   * @param data wheel measurement of the current step
    */
   void preintegration_intrinsics_2D(double dt, const WheelData &data);
   void preintegration_intrinsics_3D(double dt, const WheelData &data);

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -31,6 +31,22 @@ namespace mins {
 class State;
 class UpdaterStatistics;
 struct WheelData;
+/**
+ * \brief Partial derivatives of one 2D preintegration step, shared by the state and intrinsic Jacobians.
+ *
+ * Signs follow the error-state convention of the updater, so each term is the negated
+ * derivative of the closed-form (x, y) update.
+ */
+struct PreintegrationPartials2D {
+  double h_thw; ///< d(theta)/d(w).
+  double h_xth; ///< d(x)/d(theta).
+  double h_yth; ///< d(y)/d(theta).
+  double h_xw;  ///< d(x)/d(w).
+  double h_yw;  ///< d(y)/d(w).
+  double h_xv;  ///< d(x)/d(v).
+  double h_yv;  ///< d(y)/d(v).
+};
+
 class UpdaterWheel {
 
 public:
@@ -153,6 +169,20 @@ public:
   static Eigen::Matrix<double, 6, 1> ComputeTimeOffsetJacobian3D(const Eigen::MatrixXd &H_poses,
                                                                    const Eigen::Vector3d &w0, const Eigen::Vector3d &v0,
                                                                    const Eigen::Vector3d &w1, const Eigen::Vector3d &v1);
+
+  /**
+   * \brief Compute the partial derivatives of one 2D preintegration step.
+   *
+   * Falls back to the L'Hopital limit of each term when the angular rate is near zero.
+   *
+   * \param[in] dt Time interval for this step.
+   * \param[in] w Angular rate of the odometry frame.
+   * \param[in] v Forward velocity of the odometry frame.
+   * \param[in] th Accumulated heading angle before this step.
+   * \return Partial derivatives of this step.
+   */
+  static PreintegrationPartials2D ComputePreintegrationPartials2D(double dt, double w, double v,
+                                                                  double th);
 
   /**
    * \brief Accumulate one step of intrinsic Jacobians for the 2D wheel odometry preintegration.

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -59,6 +59,32 @@ public:
   /// Try update with available measurements
   void try_update();
 
+  /**
+   * @brief Collects a set of wheel measurements between time0 and time1
+   * @param data_vec output as a set of wheel measurements
+   * @param time0 start timestamp of the update
+   * @param state end timestamp of the update
+   */
+  bool select_wheel_data(double time0, double time1, std::vector<WheelData> &data_vec);
+
+  /**
+   * @brief Drops wheel measurements older than the given time
+   * @param oldest_time timestamp to keep measurements from
+   * @return number of measurements dropped
+   */
+  int cleanup_measurements(double oldest_time);
+
+  /// Number of wheel measurements currently in the stack
+  size_t num_measurements() const;
+
+  /**
+   * @brief Timestamps of the wheel stack usable for interpolation, which excludes the first and last measurement
+   * @param min_time output as the oldest usable timestamp
+   * @param max_time output as the newest usable timestamp
+   * @return false if the stack holds fewer than 3 measurements
+   */
+  bool measurement_time_span(double &min_time, double &max_time) const;
+
   /// chi-2 checker
   std::shared_ptr<UpdaterStatistics> Chi;
 
@@ -244,8 +270,6 @@ public:
                                                       const Eigen::Vector3d &p_3D, const Eigen::Vector3d &new_p);
 
 private:
-  friend class Initializer;
-  friend class IW_Initializer;
   /**
    * @brief Checks if we have enough clones and handover two last clone times to update
    * @param state current state info
@@ -293,14 +317,6 @@ private:
    */
   void preintegration_2D(double dt, const WheelData &data1, const WheelData &data2);
   void preintegration_3D(double dt, const WheelData &data1, const WheelData &data2);
-
-  /**
-   * @brief Collects a set of wheel measurements between time0 and time1
-   * @param data_vec output as a set of wheel measurements
-   * @param time0 start timestamp of the update
-   * @param state end timestamp of the update
-   */
-  bool select_wheel_data(double time0, double time1, std::vector<WheelData> &data_vec);
 
   /// Our history of wheel messages (time, ang_left, ang_right)
   std::vector<WheelData> data_stack;


### PR DESCRIPTION
# Modernize the wheel updater: enum-based dispatch, no duplicated formulas. No behavior change.

| # | Scope | Status |
|---|---|---|
| 1/4 | Cleanup: fix mangled doxygen, `const WheelData` by-value to const-ref, ternary-as-statement, name magic numbers | merged #87 |
| 2/4 | Wheel type `string` to enum, parsed and validated once in `OptionsWheel::load` | merged #88 |
| 3/4 | Dedup the 2D preintegration partials | open #95 |
| 4/4 | Drop `friend class Initializer` / `friend class IW_Initializer` | **THIS PR** |

A fifth PR (#89) moved the stateless Jacobian math into its own `WheelJacobians.h/.cpp`.
It is closed: the testability argument behind it did not hold, since `UpdaterWheel.h`
already forward-declared its heavy dependencies. This chain is rebased onto master
without it.

## Summary

`UpdaterWheel` handed two whole classes access to every one of its members so they
could use four things. The friendship is gone; the four things are public:

- `select_wheel_data` - already existed, just moves to the public section (`IW_Initializer`)
- `cleanup_measurements(oldest_time)` - drops old measurements, returns how many (`Initializer`)
- `num_measurements()` - stack size, for the log line that reports it
- `measurement_time_span(min_time, max_time)` - the interpolation-usable timestamp range,
  which is what `IW_Initializer` was hand-rolling out of `data_stack.at(1)` and
  `data_stack.at(size - 2)`, plus its own `size() < 3` guard

`data_stack` and the preintegration internals are private again, and this time actually
private rather than private-with-two-exceptions.

## Verification

- `catkin build mins` clean, no new warnings.
- `ctest` 5/5 pass.
- Both moved loops are line-for-line the same logic; `cleanup_measurements` swaps the
  redundant `!data_stack.empty()` re-check for the equivalent end-iterator comparison.

Note the erase-old-measurements loop in `Initializer` is copy-pasted per sensor (wheel,
GNSS, LiDAR, camera). Only the wheel copy is touched here. The other updaters could take
the same treatment, but that is their own PR.

## Chain

Chains off PR 3/4 (#95). Last PR in the campaign.


Base is master rather than #95 so the checks actually run - a PR opened against a non-master base is filtered out by every workflow, and that verdict sticks to the head SHA. The diff therefore also carries #95's commit until that one merges.

## Doxygen fixes picked up here

`select_wheel_data` moves from private to public in this PR, and its block was wrong:
no `@return` on a `bool`, and a `@param state` tag naming a parameter the function does
not have. Since the block becomes public API documentation here, it is fixed rather than
promoted as-is, along with the three others in the same file that share the fault:

| declaration | was |
|---|---|
| `select_wheel_data` | ghost `@param state`, no `@return` |
| `update` | ghost `@param state`, no `@return` |
| `interpolate_data` | no `@return` |
| `preintegration_intrinsics_2D/3D` | `@param WheelData` names the type, not the parameter `data` |

`mins/src/update/wheel/` is clean afterwards. No narrative was reworded and no signature
changed, so this stays a documentation-only delta on top of the friend removal.

An audit of the rest of `mins/src` turns up 11 more of the same class, none of them in
wheel code, so they are left alone here: `state/Propagator.h` (4, including
`select_imu_readings` which is the function this one was copied from - same ghost tags),
`state/StateHelper.h` (4), `sim/ConstBsplineSE3.h`, `sim/Simulator.h` (2),
`update/gps/PoseJPL_4DOF.h`.
