### PR TITLE
ci: add a unit test code coverage report

### DIFF
--- a/.github/scripts/gen_coverage_summary.py
+++ b/.github/scripts/gen_coverage_summary.py
@@ -1,4 +1,4 @@
-"""Turn a gcovr json-summary into the markdown coverage comment posted on each PR."""
+"""Turn a gcovr json-summary into the unit test code coverage comment posted on each PR."""
 import json, os, sys
 
 MARKER = '<!-- mins-coverage-report -->'
@@ -41,7 +41,7 @@ def summarize(report):
 
 def render(report):
     totals = summarize(report)
-    lines = [MARKER, '## Coverage', '', '| Area | Lines | Line % | Branch % |',
+    lines = [MARKER, '## Unit Test Code Coverage', '', '| Area | Lines | Line % | Branch % |',
              '|------|-------|--------|----------|']
     for name, _ in GROUPS + [('other', None)]:
         if name not in totals:
@@ -64,7 +64,7 @@ out_file = sys.argv[2] if len(sys.argv) > 2 else None
 if os.path.exists(json_path):
     summary = render(json.load(open(json_path)))
 else:
-    summary = '\n'.join([MARKER, '## Coverage', '',
+    summary = '\n'.join([MARKER, '## Unit Test Code Coverage', '',
                          '*Report not generated - check the CI log.*'])
 
 print(summary)

--- a/.github/scripts/gen_coverage_summary.py
+++ b/.github/scripts/gen_coverage_summary.py
@@ -1,0 +1,78 @@
+"""Turn a gcovr json-summary into the markdown coverage comment posted on each PR."""
+import json, os, sys
+
+MARKER = '<!-- mins-coverage-report -->'
+
+# Directories we care about enough to give their own row. Order is the order shown.
+GROUPS = [
+    ('update/wheel', 'mins/src/update/wheel/'),
+    ('update', 'mins/src/update/'),
+    ('state', 'mins/src/state/'),
+    ('init', 'mins/src/init/'),
+    ('options', 'mins/src/options/'),
+    ('core', 'mins/src/core/'),
+    ('utils', 'mins/src/utils/'),
+]
+
+
+def pct(covered, total):
+    return 100.0 * covered / total if total else 0.0
+
+
+def group_of(filename):
+    for name, prefix in GROUPS:
+        if prefix in filename:
+            return name
+    return 'other'
+
+
+def summarize(report):
+    """Accumulate per-file line/branch counts into the group buckets."""
+    totals = {}
+    for entry in report.get('files', []):
+        name = group_of(entry['filename'])
+        bucket = totals.setdefault(name, [0, 0, 0, 0])
+        bucket[0] += entry.get('line_covered', 0)
+        bucket[1] += entry.get('line_total', 0)
+        bucket[2] += entry.get('branch_covered', 0)
+        bucket[3] += entry.get('branch_total', 0)
+    return totals
+
+
+def render(report):
+    totals = summarize(report)
+    lines = [MARKER, '## Coverage', '', '| Area | Lines | Line % | Branch % |',
+             '|------|-------|--------|----------|']
+    for name, _ in GROUPS + [('other', None)]:
+        if name not in totals:
+            continue
+        line_covered, line_total, branch_covered, branch_total = totals[name]
+        lines.append('| `%s` | %d/%d | %.1f%% | %.1f%% |' % (
+            name, line_covered, line_total, pct(line_covered, line_total),
+            pct(branch_covered, branch_total)))
+    lines.append('')
+    lines.append('**Overall %.1f%% lines, %.1f%% branches** across `mins/src`.' % (
+        report.get('line_percent', 0.0), report.get('branch_percent', 0.0)))
+    lines.append('')
+    lines.append('Full HTML report is in the `coverage-html` artifact of this run.')
+    return '\n'.join(lines)
+
+
+json_path = sys.argv[1]
+out_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+if os.path.exists(json_path):
+    summary = render(json.load(open(json_path)))
+else:
+    summary = '\n'.join([MARKER, '## Coverage', '',
+                         '*Report not generated - check the CI log.*'])
+
+print(summary)
+
+gss = os.environ.get('GITHUB_STEP_SUMMARY')
+if gss:
+    with open(gss, 'a') as f:
+        f.write(summary + '\n')
+if out_file:
+    with open(out_file, 'w') as f:
+        f.write(summary + '\n')

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -65,3 +65,66 @@ jobs:
                 issue_number: context.issue.number, body,
               });
             }
+      - name: Measure coverage
+        # Separate build: -O3 inlines away the lines we want to count, so this one is -O0
+        # with --coverage. It reuses the image from the test step rather than a second job,
+        # which would mean rebuilding the whole docker image.
+        run: |
+          mkdir -p /tmp/mins_coverage
+          docker run --rm -v /tmp/mins_coverage:/results --entrypoint /bin/bash mins:noetic -c '
+            set -eo pipefail
+            apt-get update -q && apt-get install -qy --no-install-recommends libgtest-dev python3-pip
+            pip3 install -q "gcovr==7.2"
+            source /opt/ros/noetic/setup.bash
+            cd /catkin_ws
+            catkin config --cmake-args -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON
+            catkin build mins
+            cd /catkin_ws/build/mins
+            ctest || true
+            # Run from the source root with the build tree as the search path: gcovr filters
+            # relative to --root, so from inside the build tree every source looks external
+            # and the report comes back empty.
+            cd /catkin_ws/src/MINS
+            gcovr --root . \
+                  --filter mins/src/ \
+                  --exclude ".*thirdparty.*" \
+                  --gcov-ignore-parse-errors \
+                  --json-summary-pretty -o /results/coverage.json \
+                  --html-details /results/coverage.html \
+                  --print-summary \
+                  /catkin_ws/build/mins
+          '
+          python3 .github/scripts/gen_coverage_summary.py /tmp/mins_coverage/coverage.json coverage_report.md || true
+      - name: Upload coverage HTML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: /tmp/mins_coverage/*.html
+          if-no-files-found: warn
+      - name: Post coverage report to PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- mins-coverage-report -->';
+            const body = fs.existsSync('coverage_report.md')
+              ? fs.readFileSync('coverage_report.md', 'utf8')
+              : marker + '\n## Coverage\n\n*Report not generated - check the CI log.*';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body,
+              });
+            }

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -65,7 +65,7 @@ jobs:
                 issue_number: context.issue.number, body,
               });
             }
-      - name: Measure coverage
+      - name: Measure unit test code coverage
         # Separate build: -O3 inlines away the lines we want to count, so this one is -O0
         # with --coverage. It reuses the image from the test step rather than a second job,
         # which would mean rebuilding the whole docker image.
@@ -95,14 +95,14 @@ jobs:
                   /catkin_ws/build/mins
           '
           python3 .github/scripts/gen_coverage_summary.py /tmp/mins_coverage/coverage.json coverage_report.md || true
-      - name: Upload coverage HTML
+      - name: Upload unit test code coverage HTML
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: /tmp/mins_coverage/*.html
           if-no-files-found: warn
-      - name: Post coverage report to PR
+      - name: Post unit test code coverage report to PR
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -111,7 +111,7 @@ jobs:
             const marker = '<!-- mins-coverage-report -->';
             const body = fs.existsSync('coverage_report.md')
               ? fs.readFileSync('coverage_report.md', 'utf8')
-              : marker + '\n## Coverage\n\n*Report not generated - check the CI log.*';
+              : marker + '\n## Unit Test Code Coverage\n\n*Report not generated - check the CI log.*';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/mins/CMakeLists.txt
+++ b/mins/CMakeLists.txt
@@ -28,6 +28,19 @@ else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -Wmaybe-uninitialized -fno-omit-frame-pointer")
 endif ()
 
+# Coverage instrumentation (opt-in: cmake -DENABLE_COVERAGE=ON -DBUILD_TESTS=ON)
+option(ENABLE_COVERAGE "Instrument for gcov coverage. Forces -O0, so never use for a real build." OFF)
+if (ENABLE_COVERAGE)
+    if (MSVC)
+        message(FATAL_ERROR "ENABLE_COVERAGE needs a gcc or clang toolchain")
+    endif ()
+    # The -O3 set above would inline away the very lines we are trying to measure.
+    string(REPLACE "-O3" "-O0" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fno-inline -fno-inline-small-functions -fno-default-inline")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+endif ()
+
 # Include libraries (if we don't have opencv 4, then fallback to opencv 3)
 # The OpenCV version needs to match the one used by cv_bridge otherwise you will get a segmentation fault!
 find_package(Eigen3 REQUIRED QUIET)


### PR DESCRIPTION
# Get the wheel updater under unit test, and make coverage visible on every PR.

| # | Scope | Status |
|---|---|---|
| 1/6 | `ENABLE_COVERAGE` cmake option, gcovr in CI, unit test code coverage table posted on the PR | **THIS PR** |
| 2/6 | Fix `OptionsWheel` extrinsics/intrinsics defaults, add a wheel test fixture, cover `WheelTypes.h` | next |
| 3/6 | Tests for the public `UpdaterWheel` seam (measurement stack, selection, interpolation) | upcoming |
| 4/6 | Tests for preintegration and the linear system | next |
| 5/6 | Tests for `try_update` / `update`, including chi2 rejection | upcoming |
| 6/6 | Turn the report into a gate | upcoming |

## Summary

There was no way to tell what the tests actually cover. Now there is.

- `mins/CMakeLists.txt` gains `option(ENABLE_COVERAGE)`. When on it rewrites the `-O3` set
  a few lines above to `-O0`, adds `--coverage` plus the `-fno-inline` family, and puts
  `--coverage` on both linker flag sets. Off by default, and it hard-errors on MSVC.
- `.github/scripts/gen_coverage_summary.py` turns a gcovr json-summary into a markdown
  table grouped by directory under `mins/src`, with `update/wheel` first.
- The noetic workflow gets a `Measure coverage` step that reconfigures with
  `-DBUILD_TESTS=ON -DENABLE_COVERAGE=ON`, rebuilds, runs ctest, and runs gcovr. The
  table is posted as a sticky PR comment on the marker `<!-- mins-coverage-report -->`,
  the same pattern the unit test report already uses, and the HTML report is uploaded as
  the `coverage-html` artifact.

It is a second build rather than a second job because a second job would rebuild the whole
docker image. It reuses the image from the test step instead.

Nothing gates on the number yet. That is 6/6, once there is a number worth defending.

## Verification

Ran the whole thing locally in a separate catkin profile (Ubuntu 20.04, Noetic, gcc 9.4,
gcovr 7.2): build clean, `ctest` 5/5 pass under `-O0 --coverage`, and gcovr produced

| Area | Lines | Line % | Branch % |
|------|-------|--------|----------|
| `update/wheel` | 124/561 | 22.1% | 20.1% |
| `update` | 19/3124 | 0.6% | 0.9% |
| `state` | 0/1411 | 0.0% | 0.0% |
| `init` | 0/707 | 0.0% | 0.0% |
| `options` | 0/754 | 0.0% | 0.0% |
| `core` | 0/963 | 0.0% | 0.0% |
| `utils` | 0/576 | 0.0% | 0.0% |

So 1.5% overall, and the only tested directory in the repo is the wheel one at 22.1%.

One gotcha worth recording: gcovr has to run from the source root with the build tree
passed as a search path. Run it from inside the build tree and every source file looks
external to `--root`, so the report comes back empty with no error.

## Chain

First PR in the campaign.
Next in chain: PR 2/6 - `OptionsWheel` defaults are unusable without a yaml parser
(`extrinsics` is a zero-length `VectorXd` while its doxygen claims identity, which
segfaults `State::set_wheel_state`), so fix those and add the fixture the later PRs need.
