### PR TITLE
ci: compare unit test code coverage against master

### DIFF
--- a/.github/scripts/gen_coverage_summary.py
+++ b/.github/scripts/gen_coverage_summary.py
@@ -39,30 +39,57 @@ def summarize(report):
     return totals
 
 
-def render(report):
+def delta(current, previous):
+    """Change against master, coloured by direction. GitHub renders the colour as inline math."""
+    if previous is None:
+        return 'n/a'
+    change = current - previous
+    if abs(change) < 0.05:
+        return 'same'
+    return '$\color{%s}%+.1f$' % ('green' if change > 0 else 'red', change)
+
+
+def render(report, baseline):
     totals = summarize(report)
-    lines = [MARKER, '## Unit Test Code Coverage', '', '| Area | Lines | Line % | Branch % |',
-             '|------|-------|--------|----------|']
+    was = summarize(baseline) if baseline else {}
+    lines = [MARKER, '## Unit Test Code Coverage', '',
+             '| Area | Lines | Line % | vs master | Branches | Branch % | vs master |',
+             '|------|-------|--------|-----------|----------|----------|-----------|']
     for name, _ in GROUPS + [('other', None)]:
         if name not in totals:
             continue
         line_covered, line_total, branch_covered, branch_total = totals[name]
-        lines.append('| `%s` | %d/%d | %.1f%% | %.1f%% |' % (
+        before = was.get(name)
+        lines.append('| `%s` | %d/%d | %.1f%% | %s | %d/%d | %.1f%% | %s |' % (
             name, line_covered, line_total, pct(line_covered, line_total),
-            pct(branch_covered, branch_total)))
+            delta(pct(line_covered, line_total), pct(before[0], before[1]) if before else None),
+            branch_covered, branch_total, pct(branch_covered, branch_total),
+            delta(pct(branch_covered, branch_total), pct(before[2], before[3]) if before else None)))
     lines.append('')
-    lines.append('**Overall %.1f%% lines, %.1f%% branches** across `mins/src`.' % (
-        report.get('line_percent', 0.0), report.get('branch_percent', 0.0)))
+    line_percent = report.get('line_percent', 0.0)
+    branch_percent = report.get('branch_percent', 0.0)
+    lines.append('**Overall %.1f%% lines (%s), %.1f%% branches (%s)** across `mins/src`.' % (
+        line_percent, delta(line_percent, baseline.get('line_percent') if baseline else None),
+        branch_percent, delta(branch_percent, baseline.get('branch_percent') if baseline else None)))
     lines.append('')
-    lines.append('Full HTML report is in the `coverage-html` artifact of this run.')
+    if baseline is None:
+        lines.append('No master baseline was available for this run, so the comparison columns '
+                     'are empty. They fill in once a master build has published a report.')
+        lines.append('')
+    lines.append('Full HTML report is in the `coverage-report` artifact of this run.')
     return '\n'.join(lines)
 
 
 json_path = sys.argv[1]
 out_file = sys.argv[2] if len(sys.argv) > 2 else None
+baseline_path = sys.argv[3] if len(sys.argv) > 3 else None
+
+baseline = None
+if baseline_path and os.path.exists(baseline_path):
+    baseline = json.load(open(baseline_path))
 
 if os.path.exists(json_path):
-    summary = render(json.load(open(json_path)))
+    summary = render(json.load(open(json_path)), baseline)
 else:
     summary = '\n'.join([MARKER, '## Unit Test Code Coverage', '',
                          '*Report not generated - check the CI log.*'])

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  actions: read
 
 jobs:
 
@@ -65,6 +66,16 @@ jobs:
                 issue_number: context.issue.number, body,
               });
             }
+      - name: Fetch the master unit test code coverage baseline
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/mins_baseline
+          run_id=$(gh run list --workflow "${{ github.workflow }}" --branch master --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [ -n "$run_id" ]; then
+            gh run download "$run_id" --name coverage-report --dir /tmp/mins_baseline || true
+          fi
       - name: Measure unit test code coverage
         # Separate build: -O3 inlines away the lines we want to count, so this one is -O0
         # with --coverage. It reuses the image from the test step rather than a second job,
@@ -94,13 +105,15 @@ jobs:
                   --print-summary \
                   /catkin_ws/build/mins
           '
-          python3 .github/scripts/gen_coverage_summary.py /tmp/mins_coverage/coverage.json coverage_report.md || true
-      - name: Upload unit test code coverage HTML
+          python3 .github/scripts/gen_coverage_summary.py /tmp/mins_coverage/coverage.json \n            coverage_report.md /tmp/mins_baseline/coverage.json || true
+      - name: Upload unit test code coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
-          path: /tmp/mins_coverage/*.html
+          name: coverage-report
+          path: |
+            /tmp/mins_coverage/*.html
+            /tmp/mins_coverage/coverage.json
           if-no-files-found: warn
       - name: Post unit test code coverage report to PR
         if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
# Get the wheel updater under unit test, and make coverage visible on every PR.

| # | Scope | Status |
|---|---|---|
| 1/6 | `ENABLE_COVERAGE` cmake option, gcovr in CI, unit test code coverage table posted on the PR | shipped #92 |
| 1/6b | Compare that table against master and colour the direction | **THIS PR** |
| 2/6 | Fix `OptionsWheel` extrinsics/intrinsics defaults, one test file per source | shipped #93 |
| 3/6 | Tests for the public `UpdaterWheel` seam (measurement stack, selection, interpolation) | open #94 |
| 4/6 | Tests for preintegration and the linear system | next |
| 5/6 | Tests for `try_update` / `update`, including chi2 rejection | upcoming |
| 6/6 | Turn the report into a gate | upcoming |

## Summary

The report from 1/6 only ever printed the current numbers, so `39.0%` on a PR gave no way
to tell whether the PR raised coverage or lowered it. Two changes fix that.

**Branch counts, not just a percentage.** The branch column now carries its ratio the same
way lines do, since `25.6%` alone hides how big the denominator is - `441/1721` for
`update/wheel`, where the 1721 includes every implicit branch g++ emits for a throwing
Eigen expression.

**A comparison against master.** Master pushes already run the coverage step, but only the
HTML left the run, so there was nothing to diff against. The artifact now carries
`coverage.json` too, and a PR run pulls the newest successful master report with
`gh run download` before rendering. Each area gets a `vs master` column: green when the
percentage went up, red when it went down, which is the "code added without a test" case.
Colour is inline math - the only thing GitHub renders coloured in a comment - and the
lookup needs `actions: read`.

The first PR after this merges will say the baseline is missing, since no master run has
published a `coverage.json` yet. It fills in on the next master build.

| Area | Lines | Line % | vs master | Branches | Branch % | vs master |
|------|-------|--------|-----------|----------|----------|-----------|
| `update/wheel` | 221/566 | 39.0% | $\color{green}+15.7$ | 441/1721 | 25.6% | $\color{green}+10.3$ |
| `options` | 33/754 | 4.4% | $\color{red}-8.6$ | 8/2510 | 0.3% | same |

## Verification

- Rendered locally against a real gcovr report with a hand-edited baseline, which is the
  table above.
- The colour syntax was checked against GitHub's own renderer before being used: it comes
  back wrapped in `math-renderer class="js-inline-math"`, so it is rendered, not printed.
- Workflow parses as YAML; no other workflow touched.

## Chain

Independent of the test PRs, so the base is master.
Next in chain: PR 4/6 - preintegration and the linear system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
