### PR TITLE
wheel: test the preintegration helpers

### DIFF
--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -527,6 +527,97 @@ void UpdaterWheel::preintegration_intrinsics_3D(double dt, const WheelData &data
   AccumulateIntrinsicJacobians3D(dt, data.m1, data.m2, R_3D, rl, rr, b, dR_di_3D, dp_di_3D);
 }
 
+OdometryVelocity UpdaterWheel::ComputeOdometryVelocity(WheelType type, const WheelData &data, double rl, double rr,
+                                                       double b) {
+  switch (ModalityOf(type)) {
+  case WheelModality::Angular:
+    return {(data.m2 * rr - data.m1 * rl) / b, (data.m2 * rr + data.m1 * rl) / 2};
+  case WheelModality::Linear:
+    return {(data.m2 - data.m1) / b, (data.m2 + data.m1) / 2};
+  case WheelModality::Centered:
+    return {data.m1, data.m2};
+  }
+  return {0, 0};
+}
+
+Vector3d UpdaterWheel::IntegrateMean2D(double dt, const OdometryVelocity &vel0, const OdometryVelocity &vel1,
+                                       double th, double x, double y) {
+  double w_alpha = (vel1.w - vel0.w) / dt;
+  double v_jerk = (vel1.v - vel0.v) / dt;
+
+  // k1 ================
+  double w = vel0.w;
+  double v = vel0.v;
+  double k1_th = -w * dt;
+  double k1_x = v * 1 * dt;
+
+  // k2 ================
+  double th2 = 0.5 * k1_th;
+  w += 0.5 * w_alpha * dt;
+  v += 0.5 * v_jerk * dt;
+  double k2_th = -w * dt;
+  double k2_x = v * cos(th2) * dt;
+
+  // k3 ================
+  double th3 = 0.5 * k2_th;
+  double k3_th = -w * dt;
+  double k3_x = v * cos(th3) * dt;
+
+  // k4 ================
+  double th4 = k3_th;
+  w += 0.5 * w_alpha * dt;
+  v += 0.5 * v_jerk * dt;
+  double k4_th = -w * dt;
+  double k4_x = v * cos(th4) * dt;
+
+  // integrated value
+  double th_next = th + (1.0 / 6.0) * (k1_th + 2 * k2_th + 2 * k3_th + k4_th);
+  double x_next = x + (1.0 / 6.0) * (k1_x + 2 * k2_x + 2 * k3_x + k4_x);
+  double y_next;
+
+  if (abs(vel0.w) < SMALL_ANGULAR_RATE) // In case w is too small, apply L'Hopital rule
+    y_next = y - vel0.v * sin(th - vel0.w * dt) * dt;
+  else // use discrete integration value for y because it is working better for some unknown reason...
+    y_next = y - (vel0.v * (cos(th - vel0.w * dt) - cos(th))) / vel0.w;
+
+  return {th_next, x_next, y_next};
+}
+
+void UpdaterWheel::ComputeVelocityNoiseJacobians(WheelType type, double rl, double rr, double b,
+                                                 Matrix<double, 1, 2> &Hwn, Matrix<double, 1, 2> &Hvn) {
+  switch (ModalityOf(type)) {
+  case WheelModality::Angular:
+    Hwn << rl / b, -rr / b;
+    Hvn << -rl / 2, -rr / 2;
+    break;
+  case WheelModality::Linear:
+    Hwn << 1.0 / b, -1.0 / b;
+    Hvn << -1.0 / 2, -1.0 / 2;
+    break;
+  case WheelModality::Centered:
+    Hwn << 1, 0;
+    Hvn << 0, 1;
+    break;
+  }
+}
+
+Matrix2d UpdaterWheel::ComputeMeasurementCovariance2D(WheelType type, double noise_w, double noise_v, double dt) {
+  Matrix2d Q = Matrix2d::Zero();
+  switch (ModalityOf(type)) {
+  case WheelModality::Angular:
+    Q = pow(noise_w, 2) / dt * Matrix2d::Identity();
+    break;
+  case WheelModality::Linear:
+    Q = pow(noise_v, 2) / dt * Matrix2d::Identity();
+    break;
+  case WheelModality::Centered:
+    Q(0, 0) = pow(noise_w, 2) / dt;
+    Q(1, 1) = pow(noise_v, 2) / dt;
+    break;
+  }
+  return Q;
+}
+
 void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const WheelData &data2) {
 
   // load intrinsic values
@@ -535,98 +626,18 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
   double b = state->wheel_intrinsic->value()(2);
 
   // compute the velocities at the odometry frame
-  double w1 = 0, w2 = 0, v1 = 0, v2 = 0;
-  switch (ModalityOf(state->op->wheel->type)) {
-  case WheelModality::Angular:
-    w1 = (data1.m2 * rr - data1.m1 * rl) / b;
-    v1 = (data1.m2 * rr + data1.m1 * rl) / 2;
-    w2 = (data2.m2 * rr - data2.m1 * rl) / b;
-    v2 = (data2.m2 * rr + data2.m1 * rl) / 2;
-    break;
-  case WheelModality::Linear:
-    w1 = (data1.m2 - data1.m1) / b;
-    v1 = (data1.m2 + data1.m1) / 2;
-    w2 = (data2.m2 - data2.m1) / b;
-    v2 = (data2.m2 + data2.m1) / 2;
-    break;
-  case WheelModality::Centered:
-    w1 = data1.m1;
-    v1 = data1.m2;
-    w2 = data2.m1;
-    v2 = data2.m2;
-    break;
-  }
+  const OdometryVelocity vel1 = ComputeOdometryVelocity(state->op->wheel->type, data1, rl, rr, b);
+  const OdometryVelocity vel2 = ComputeOdometryVelocity(state->op->wheel->type, data2, rl, rr, b);
 
-  // =========================================================
   // Compute means
-  // =========================================================
-  double w_alpha = (w2 - w1) / dt;
-  double v_jerk = (v2 - v1) / dt;
-
-  // k1 ================
-  double w = w1;
-  double v = v1;
-  double k1_th = -w * dt;
-  double k1_x = v * 1 * dt;
-  double k1_y = -v * 0 * dt;
-
-  // k2 ================
-  double th2 = 0.5 * k1_th;
-  w += 0.5 * w_alpha * dt;
-  v += 0.5 * v_jerk * dt;
-  double k2_th = -w * dt;
-  double k2_x = v * cos(th2) * dt;
-  double k2_y = -v * sin(th2) * dt;
-
-  // k3 ================
-  double th3 = 0.5 * k2_th;
-  double k3_th = -w * dt;
-  double k3_x = v * cos(th3) * dt;
-  double k3_y = -v * sin(th3) * dt;
-
-  // k4 ================
-  double th4 = k3_th;
-  w += 0.5 * w_alpha * dt;
-  v += 0.5 * v_jerk * dt;
-  double k4_th = -w * dt;
-  double k4_x = v * cos(th4) * dt;
-  double k4_y = -v * sin(th4) * dt;
-
-  // integrated value
-  double th_next = th_2D + (1.0 / 6.0) * (k1_th + 2 * k2_th + 2 * k3_th + k4_th);
-  double x_next = x_2D + (1.0 / 6.0) * (k1_x + 2 * k2_x + 2 * k3_x + k4_x);
-  double y_next = y_2D + (1.0 / 6.0) * (k1_y + 2 * k2_y + 2 * k3_y + k4_y);
-
-  if (abs(w1) < SMALL_ANGULAR_RATE) // In case w is too small, apply L'Hopital rule
-    y_next = y_2D - v1 * sin(th_2D - w1 * dt) * dt;
-  else // use discrete integration value for y because it is working better for some unknown reason...
-    y_next = y_2D - (v1 * (cos(th_2D - w1 * dt) - cos(th_2D))) / w1;
+  const Vector3d mean_next = IntegrateMean2D(dt, vel1, vel2, th_2D, x_2D, y_2D);
 
   // Compute noise Jacobians respect to measurements
   Matrix<double, 1, 2> Hwn, Hvn;
-  switch (ModalityOf(state->op->wheel->type)) {
-  case WheelModality::Angular:
-    Hwn(0, 0) = rl / b;
-    Hwn(0, 1) = -rr / b;
-    Hvn(0, 0) = -rl / 2;
-    Hvn(0, 1) = -rr / 2;
-    break;
-  case WheelModality::Linear:
-    Hwn(0, 0) = 1.0 / b;
-    Hwn(0, 1) = -1.0 / b;
-    Hvn(0, 0) = -1.0 / 2;
-    Hvn(0, 1) = -1.0 / 2;
-    break;
-  case WheelModality::Centered:
-    Hwn(0, 0) = 1;
-    Hwn(0, 1) = 0;
-    Hvn(0, 0) = 0;
-    Hvn(0, 1) = 1;
-    break;
-  }
+  ComputeVelocityNoiseJacobians(state->op->wheel->type, rl, rr, b, Hwn, Hvn);
 
   // Compute Jacobians respect to state preintegrated state and the measurement
-  const PreintegrationPartials2D partials = ComputePreintegrationPartials2D(dt, w1, v1, th_2D);
+  const PreintegrationPartials2D partials = ComputePreintegrationPartials2D(dt, vel1.w, vel1.v, th_2D);
 
   // Compute the Jacobians with respect to the current preintegrated states
   Matrix3d Phi_tr = Matrix3d::Identity();
@@ -640,28 +651,17 @@ void UpdaterWheel::preintegration_2D(double dt, const WheelData &data1, const Wh
   Phi_ns.block(2, 0, 1, 2) = partials.h_yw * Hwn + partials.h_yv * Hvn;
 
   // Compute Measurement covariance
-  Matrix2d Q = Matrix2d::Zero();
-  switch (ModalityOf(state->op->wheel->type)) {
-  case WheelModality::Angular:
-    Q = pow(state->op->wheel->noise_w, 2) / dt * Matrix2d::Identity();
-    break;
-  case WheelModality::Linear:
-    Q = pow(state->op->wheel->noise_v, 2) / dt * Matrix2d::Identity();
-    break;
-  case WheelModality::Centered:
-    Q(0, 0) = pow(state->op->wheel->noise_w, 2) / dt;
-    Q(1, 1) = pow(state->op->wheel->noise_v, 2) / dt;
-    break;
-  }
+  const Matrix2d Q = ComputeMeasurementCovariance2D(state->op->wheel->type, state->op->wheel->noise_w,
+                                                    state->op->wheel->noise_v, dt);
 
   // integrate noise covarinace
   Cov_2D = Phi_tr * Cov_2D * Phi_tr.transpose() + Phi_ns * Q * Phi_ns.transpose();
   Cov_2D = 0.5 * (Cov_2D + Cov_2D.transpose());
 
   // integrate the measurement
-  th_2D = th_next;
-  x_2D = x_next;
-  y_2D = y_next;
+  th_2D = mean_next(0);
+  x_2D = mean_next(1);
+  y_2D = mean_next(2);
 }
 
 Matrix<double, 6, 6> UpdaterWheel::ComputePhiTr3D(const Matrix3d &R_3D, const Matrix3d &R_new,
@@ -673,43 +673,13 @@ Matrix<double, 6, 6> UpdaterWheel::ComputePhiTr3D(const Matrix3d &R_3D, const Ma
   return Phi_tr;
 }
 
-void UpdaterWheel::preintegration_3D(double dt, const WheelData &data1, const WheelData &data2) {
-
-  // load intrinsic values
-  double rl = state->wheel_intrinsic->value()(0);
-  double rr = state->wheel_intrinsic->value()(1);
-  double b = state->wheel_intrinsic->value()(2);
-
-  // compute the velocities at the odometry frame
-  Vector3d w_hat1, v_hat1, w_hat2, v_hat2;
-  switch (ModalityOf(state->op->wheel->type)) {
-  case WheelModality::Angular:
-    w_hat1 << 0, 0, (data1.m2 * rr - data1.m1 * rl) / b;
-    v_hat1 << (data1.m2 * rr + data1.m1 * rl) / 2, 0, 0;
-    w_hat2 << 0, 0, (data2.m2 * rr - data2.m1 * rl) / b;
-    v_hat2 << (data2.m2 * rr + data2.m1 * rl) / 2, 0, 0;
-    break;
-  case WheelModality::Linear:
-    w_hat1 << 0, 0, (data1.m2 - data1.m1) / b;
-    v_hat1 << (data1.m2 + data1.m1) / 2, 0, 0;
-    w_hat2 << 0, 0, (data2.m2 - data2.m1) / b;
-    v_hat2 << (data2.m2 + data2.m1) / 2, 0, 0;
-    break;
-  case WheelModality::Centered:
-    w_hat1 << 0, 0, data1.m1;
-    v_hat1 << data1.m2, 0, 0;
-    w_hat2 << 0, 0, data2.m1;
-    v_hat2 << data2.m2, 0, 0;
-    break;
-  }
-
-  // =========================================================
-  // Compute means
-  // =========================================================
-  Vector3d w_hat = w_hat1;
-  Vector3d v_hat = v_hat1;
-  Vector3d w_alpha = (w_hat2 - w_hat1) / dt;
-  Vector3d v_jerk = (v_hat2 - v_hat1) / dt;
+void UpdaterWheel::IntegrateMean3D(double dt, const Vector3d &w_hat0, const Vector3d &v_hat0, const Vector3d &w_hat1,
+                                   const Vector3d &v_hat1, const Matrix3d &R_3D, const Vector3d &p_3D,
+                                   Matrix3d &R_new, Vector3d &new_p) {
+  Vector3d w_hat = w_hat0;
+  Vector3d v_hat = v_hat0;
+  Vector3d w_alpha = (w_hat1 - w_hat0) / dt;
+  Vector3d v_jerk = (v_hat1 - v_hat0) / dt;
   Vector4d q_local = rot_2_quat(R_3D);
 
   // k1 ================
@@ -751,37 +721,55 @@ void UpdaterWheel::preintegration_3D(double dt, const WheelData &data1, const Wh
   // integrated value
   Vector4d dq = quatnorm(dq_0 + (1.0 / 6.0) * k1_q + (1.0 / 3.0) * k2_q + (1.0 / 3.0) * k3_q + (1.0 / 6.0) * k4_q);
   Vector4d new_q = quat_multiply(dq, q_local);
-  Matrix3d R_new = quat_2_Rot(new_q);
-  Vector3d new_p = p_3D + (1.0 / 6.0) * k1_p + (1.0 / 3.0) * k2_p + (1.0 / 3.0) * k3_p + (1.0 / 6.0) * k4_p;
+  R_new = quat_2_Rot(new_q);
+  new_p = p_3D + (1.0 / 6.0) * k1_p + (1.0 / 3.0) * k2_p + (1.0 / 3.0) * k3_p + (1.0 / 6.0) * k4_p;
+}
 
-  // compute measurement noise
+Matrix<double, 6, 6> UpdaterWheel::ComputeMeasurementCovariance3D(WheelType type, double noise_w, double noise_v,
+                                                                  double noise_p, double b, double dt) {
   Matrix<double, 6, 6> Q = Matrix<double, 6, 6>::Zero();
-  switch (ModalityOf(state->op->wheel->type)) {
+  Q(0, 0) = pow(noise_p, 2) / dt;
+  Q(1, 1) = pow(noise_p, 2) / dt;
+  Q(4, 4) = pow(noise_p, 2) / dt;
+  Q(5, 5) = pow(noise_p, 2) / dt;
+  switch (ModalityOf(type)) {
   case WheelModality::Angular:
-    Q.block(0, 0, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(1, 1, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(2, 2, 1, 1) << pow(state->op->wheel->noise_w, 2) / dt;
-    Q.block(3, 3, 1, 1) << pow(state->op->wheel->noise_v, 2) / dt;
-    Q.block(4, 4, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(5, 5, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
+  case WheelModality::Centered:
+    Q(2, 2) = pow(noise_w, 2) / dt;
+    Q(3, 3) = pow(noise_v, 2) / dt;
     break;
   case WheelModality::Linear:
-    Q.block(0, 0, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(1, 1, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(2, 2, 1, 1) << 2 * pow(state->op->wheel->noise_v, 2) / b / b / dt;
-    Q.block(3, 3, 1, 1) << pow(state->op->wheel->noise_v, 2) / 2 / dt;
-    Q.block(4, 4, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(5, 5, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    break;
-  case WheelModality::Centered:
-    Q.block(0, 0, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(1, 1, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(2, 2, 1, 1) << pow(state->op->wheel->noise_w, 2) / dt;
-    Q.block(3, 3, 1, 1) << pow(state->op->wheel->noise_v, 2) / dt;
-    Q.block(4, 4, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
-    Q.block(5, 5, 1, 1) << pow(state->op->wheel->noise_p, 2) / dt;
+    Q(2, 2) = 2 * pow(noise_v, 2) / b / b / dt;
+    Q(3, 3) = pow(noise_v, 2) / 2 / dt;
     break;
   }
+  return Q;
+}
+
+void UpdaterWheel::preintegration_3D(double dt, const WheelData &data1, const WheelData &data2) {
+
+  // load intrinsic values
+  double rl = state->wheel_intrinsic->value()(0);
+  double rr = state->wheel_intrinsic->value()(1);
+  double b = state->wheel_intrinsic->value()(2);
+
+  // compute the velocities at the odometry frame
+  const OdometryVelocity vel1 = ComputeOdometryVelocity(state->op->wheel->type, data1, rl, rr, b);
+  const OdometryVelocity vel2 = ComputeOdometryVelocity(state->op->wheel->type, data2, rl, rr, b);
+  const Vector3d w_hat1(0, 0, vel1.w);
+  const Vector3d v_hat1(vel1.v, 0, 0);
+  const Vector3d w_hat2(0, 0, vel2.w);
+  const Vector3d v_hat2(vel2.v, 0, 0);
+
+  // Compute means
+  Matrix3d R_new;
+  Vector3d new_p;
+  IntegrateMean3D(dt, w_hat1, v_hat1, w_hat2, v_hat2, R_3D, p_3D, R_new, new_p);
+
+  // compute measurement noise
+  const Matrix<double, 6, 6> Q = ComputeMeasurementCovariance3D(state->op->wheel->type, state->op->wheel->noise_w,
+                                                                state->op->wheel->noise_v, state->op->wheel->noise_p,
+                                                                b, dt);
 
   // Compute the Jacobians with respect to the current preintegrated measurements
   Matrix<double, 6, 6> Phi_tr = ComputePhiTr3D(R_3D, R_new, p_3D, new_p);

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -21,6 +21,7 @@
 #ifndef MINS_UPDATERWHEEL_H
 #define MINS_UPDATERWHEEL_H
 
+#include "WheelTypes.h"
 #include <Eigen/Eigen>
 #include <deque>
 #include <memory>
@@ -45,6 +46,12 @@ struct PreintegrationPartials2D {
   double h_yw;  ///< d(y)/d(w).
   double h_xv;  ///< d(x)/d(v).
   double h_yv;  ///< d(y)/d(v).
+};
+
+/// Angular and forward velocity of the wheel odometry frame, resolved from one raw reading.
+struct OdometryVelocity {
+  double w; ///< Angular rate of the odometry frame, rad/s.
+  double v; ///< Forward velocity of the odometry frame, m/s.
 };
 
 class UpdaterWheel {
@@ -269,6 +276,96 @@ public:
    */
   static Eigen::Matrix<double, 6, 6> ComputePhiTr3D(const Eigen::Matrix3d &R_3D, const Eigen::Matrix3d &R_new,
                                                       const Eigen::Vector3d &p_3D, const Eigen::Vector3d &new_p);
+
+  /**
+   * \brief Resolve one raw wheel reading into the velocities of the odometry frame.
+   *
+   * The intrinsics are ignored by every modality but Angular, which is the only one whose
+   * readings are wheel-side rather than frame-side.
+   *
+   * \param[in] type Wheel type of the reading.
+   * \param[in] data Raw wheel reading.
+   * \param[in] rl Left wheel radius.
+   * \param[in] rr Right wheel radius.
+   * \param[in] b Wheel baseline.
+   * \return Velocities of the odometry frame.
+   */
+  static OdometryVelocity ComputeOdometryVelocity(WheelType type, const WheelData &data, double rl, double rr,
+                                                   double b);
+
+  /**
+   * \brief Runge-Kutta integration of one 2D preintegration step.
+   *
+   * The lateral term falls back to its L'Hopital limit when the angular rate is near zero.
+   *
+   * \param[in] dt Time interval for this step.
+   * \param[in] vel0 Odometry velocities at the start of the step.
+   * \param[in] vel1 Odometry velocities at the end of the step.
+   * \param[in] th Accumulated heading angle before this step.
+   * \param[in] x Accumulated forward displacement before this step.
+   * \param[in] y Accumulated lateral displacement before this step.
+   * \return Accumulated [heading, x, y] after this step.
+   */
+  static Eigen::Vector3d IntegrateMean2D(double dt, const OdometryVelocity &vel0, const OdometryVelocity &vel1,
+                                          double th, double x, double y);
+
+  /**
+   * \brief Runge-Kutta integration of one 3D preintegration step.
+   *
+   * \param[in] dt Time interval for this step.
+   * \param[in] w_hat0 Angular velocity of the odometry frame at the start of the step.
+   * \param[in] v_hat0 Linear velocity of the odometry frame at the start of the step.
+   * \param[in] w_hat1 Angular velocity of the odometry frame at the end of the step.
+   * \param[in] v_hat1 Linear velocity of the odometry frame at the end of the step.
+   * \param[in] R_3D Accumulated rotation before this step.
+   * \param[in] p_3D Accumulated position before this step.
+   * \param[out] R_new Accumulated rotation after this step.
+   * \param[out] new_p Accumulated position after this step.
+   */
+  static void IntegrateMean3D(double dt, const Eigen::Vector3d &w_hat0, const Eigen::Vector3d &v_hat0,
+                               const Eigen::Vector3d &w_hat1, const Eigen::Vector3d &v_hat1,
+                               const Eigen::Matrix3d &R_3D, const Eigen::Vector3d &p_3D,
+                               Eigen::Matrix3d &R_new, Eigen::Vector3d &new_p);
+
+  /**
+   * \brief Derivatives of the odometry frame velocities with respect to the two raw readings.
+   * \param[in] type Wheel type of the readings.
+   * \param[in] rl Left wheel radius.
+   * \param[in] rr Right wheel radius.
+   * \param[in] b Wheel baseline.
+   * \param[out] Hwn d(w)/d([m1, m2]).
+   * \param[out] Hvn d(v)/d([m1, m2]).
+   */
+  static void ComputeVelocityNoiseJacobians(WheelType type, double rl, double rr, double b,
+                                             Eigen::Matrix<double, 1, 2> &Hwn,
+                                             Eigen::Matrix<double, 1, 2> &Hvn);
+
+  /**
+   * \brief Continuous-time noise covariance of one 2D wheel reading, discretized over the step.
+   * \param[in] type Wheel type of the reading.
+   * \param[in] noise_w Angular measurement noise.
+   * \param[in] noise_v Linear measurement noise.
+   * \param[in] dt Time interval for this step.
+   * \return 2x2 measurement noise covariance.
+   */
+  static Eigen::Matrix2d ComputeMeasurementCovariance2D(WheelType type, double noise_w, double noise_v, double dt);
+
+  /**
+   * \brief Continuous-time noise covariance of one 3D wheel reading, discretized over the step.
+   *
+   * The four off-plane entries carry the planar motion constraint, so they are driven by the
+   * constraint noise rather than by either measurement noise.
+   *
+   * \param[in] type Wheel type of the reading.
+   * \param[in] noise_w Angular measurement noise.
+   * \param[in] noise_v Linear measurement noise.
+   * \param[in] noise_p Planar motion constraint noise.
+   * \param[in] b Wheel baseline.
+   * \param[in] dt Time interval for this step.
+   * \return 6x6 measurement noise covariance, ordered [w(3), v(3)].
+   */
+  static Eigen::Matrix<double, 6, 6> ComputeMeasurementCovariance3D(WheelType type, double noise_w, double noise_v,
+                                                                     double noise_p, double b, double dt);
 
 private:
   /**

--- a/mins/tests/test_UpdaterWheel.cpp
+++ b/mins/tests/test_UpdaterWheel.cpp
@@ -1,7 +1,8 @@
 // Unit tests for mins/src/update/wheel/UpdaterWheel: the OptionsWheel defaults it relies on,
-// its measurement stack, and its analytical Jacobians.
+// its measurement stack, its preintegration steps, and its analytical Jacobians.
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <cmath>
 
 #include "options/OptionsCamera.h"
 #include "options/OptionsEstimator.h"
@@ -773,4 +774,198 @@ TEST(SelectWheelData, FailsWhenOnlyOneSampleLandsInTheWindow) {
     std::shared_ptr<UpdaterWheel> updater = MakeUpdater({0.0, 10.0});
     std::vector<WheelData> data_vec;
     EXPECT_FALSE(updater->select_wheel_data(1.0, 2.0, data_vec));
+}
+
+// ---- Preintegration ----
+
+TEST(OdometryVelocity, AngularScalesTheReadingsByTheWheelRadii) {
+    WheelData data;
+    data.m1 = 1.3;
+    data.m2 = 2.1;
+    const OdometryVelocity vel = UpdaterWheel::ComputeOdometryVelocity(WheelType::Wheel2DAng, data, 0.2, 0.25, 0.6);
+    EXPECT_DOUBLE_EQ(vel.w, (2.1 * 0.25 - 1.3 * 0.2) / 0.6);
+    EXPECT_DOUBLE_EQ(vel.v, (2.1 * 0.25 + 1.3 * 0.2) / 2);
+}
+
+TEST(OdometryVelocity, LinearAndCenteredIgnoreTheWheelRadii) {
+    WheelData data;
+    data.m1 = 1.3;
+    data.m2 = 2.1;
+    for (WheelType type : {WheelType::Wheel2DLin, WheelType::Wheel2DCen}) {
+        const OdometryVelocity vel = UpdaterWheel::ComputeOdometryVelocity(type, data, 0.2, 0.25, 0.6);
+        const OdometryVelocity other = UpdaterWheel::ComputeOdometryVelocity(type, data, 9.9, 9.9, 0.6);
+        EXPECT_DOUBLE_EQ(vel.w, other.w) << ToString(type);
+        EXPECT_DOUBLE_EQ(vel.v, other.v) << ToString(type);
+    }
+    const OdometryVelocity centered = UpdaterWheel::ComputeOdometryVelocity(WheelType::Wheel2DCen, data, 0.2, 0.25, 0.6);
+    EXPECT_DOUBLE_EQ(centered.w, data.m1);
+    EXPECT_DOUBLE_EQ(centered.v, data.m2);
+}
+
+TEST(OdometryVelocity, The3DTypesResolveLikeTheir2DCounterparts) {
+    WheelData data;
+    data.m1 = 1.3;
+    data.m2 = 2.1;
+    const WheelType pairs[3][2] = {{WheelType::Wheel2DAng, WheelType::Wheel3DAng},
+                                   {WheelType::Wheel2DLin, WheelType::Wheel3DLin},
+                                   {WheelType::Wheel2DCen, WheelType::Wheel3DCen}};
+    for (const WheelType *pair : pairs) {
+        const OdometryVelocity flat = UpdaterWheel::ComputeOdometryVelocity(pair[0], data, 0.2, 0.25, 0.6);
+        const OdometryVelocity full = UpdaterWheel::ComputeOdometryVelocity(pair[1], data, 0.2, 0.25, 0.6);
+        EXPECT_DOUBLE_EQ(flat.w, full.w) << ToString(pair[1]);
+        EXPECT_DOUBLE_EQ(flat.v, full.v) << ToString(pair[1]);
+    }
+}
+
+TEST(IntegrateMean2D, StraightLineMovesAlongXOnly) {
+    const Vector3d next = UpdaterWheel::IntegrateMean2D(0.1, {0.0, 2.0}, {0.0, 2.0}, 0.0, 0.0, 0.0);
+    EXPECT_NEAR(next(0), 0.0, 1e-12);
+    EXPECT_NEAR(next(1), 0.2, 1e-12);
+    EXPECT_NEAR(next(2), 0.0, 1e-12);
+}
+
+TEST(IntegrateMean2D, ConstantTurnTracesACircularArc) {
+    const double w = 0.4;
+    const double v = 1.5;
+    const double dt = 0.001;
+    const int N = 500;
+    double th = 0.0, x = 0.0, y = 0.0;
+    for (int i = 0; i < N; i++) {
+        const Vector3d next = UpdaterWheel::IntegrateMean2D(dt, {w, v}, {w, v}, th, x, y);
+        th = next(0);
+        x = next(1);
+        y = next(2);
+    }
+    const double total = N * dt;
+    EXPECT_NEAR(th, -w * total, 1e-9);
+    EXPECT_NEAR(y, v * (1 - std::cos(w * total)) / w, 1e-6);
+    // x comes out as the path length, not the arc chord: the stage headings th2/th3/th4 are the
+    // heading change inside the step, so the accumulated heading never reaches the x update. y is
+    // spared because it is overwritten by a closed form that does use it. Pinned as-is; the
+    // expectation this should meet is in the disabled test below.
+    EXPECT_NEAR(x, v * total, 1e-6);
+}
+
+TEST(IntegrateMean2D, DISABLED_ForwardDisplacementFollowsTheAccumulatedHeading) {
+    // The value ComputePreintegrationPartials2D linearizes about: h_xv is d/dv of the closed form
+    // -(v * (sin(th - w * dt) - sin(th))) / w, so the filter's Jacobian already assumes this arc.
+    const double w = 0.4;
+    const double v = 1.5;
+    const double dt = 0.001;
+    const int N = 500;
+    double th = 0.0, x = 0.0, y = 0.0;
+    for (int i = 0; i < N; i++) {
+        const Vector3d next = UpdaterWheel::IntegrateMean2D(dt, {w, v}, {w, v}, th, x, y);
+        th = next(0);
+        x = next(1);
+        y = next(2);
+    }
+    EXPECT_NEAR(x, v * std::sin(w * N * dt) / w, 1e-6);
+}
+
+TEST(IntegrateMean2D, NearZeroRateAgreesWithTheGeneralBranch) {
+    // Either side of the rate below which the closed form is replaced by its limit.
+    const double v = 1.5;
+    const double dt = 0.01;
+    const double th = 0.3;
+    const Vector3d below = UpdaterWheel::IntegrateMean2D(dt, {0.99e-4, v}, {0.99e-4, v}, th, 0.0, 0.0);
+    const Vector3d above = UpdaterWheel::IntegrateMean2D(dt, {1.01e-4, v}, {1.01e-4, v}, th, 0.0, 0.0);
+    EXPECT_NEAR(below(2), above(2), 1e-8);
+}
+
+TEST(IntegrateMean3D, StraightLineMatchesThe2DIntegrator) {
+    const double v = 2.0;
+    const double dt = 0.05;
+    Matrix3d R_new;
+    Vector3d p_new;
+    UpdaterWheel::IntegrateMean3D(dt, Vector3d::Zero(), Vector3d(v, 0, 0), Vector3d::Zero(), Vector3d(v, 0, 0),
+                                  Matrix3d::Identity(), Vector3d::Zero(), R_new, p_new);
+    const Vector3d flat = UpdaterWheel::IntegrateMean2D(dt, {0.0, v}, {0.0, v}, 0.0, 0.0, 0.0);
+    EXPECT_TRUE(R_new.isApprox(Matrix3d::Identity()));
+    EXPECT_NEAR(p_new(0), flat(1), 1e-12);
+    EXPECT_NEAR(p_new(1), flat(2), 1e-12);
+    EXPECT_NEAR(p_new(2), 0.0, 1e-12);
+}
+
+TEST(IntegrateMean3D, ConstantYawRateTracesTheSameArcAs2D) {
+    const double w = 0.4;
+    const double v = 1.5;
+    const double dt = 0.001;
+    const int N = 500;
+    Matrix3d R = Matrix3d::Identity();
+    Vector3d p = Vector3d::Zero();
+    for (int i = 0; i < N; i++) {
+        Matrix3d R_new;
+        Vector3d p_new;
+        UpdaterWheel::IntegrateMean3D(dt, Vector3d(0, 0, w), Vector3d(v, 0, 0), Vector3d(0, 0, w), Vector3d(v, 0, 0),
+                                      R, p, R_new, p_new);
+        R = R_new;
+        p = p_new;
+    }
+    const double total = N * dt;
+    EXPECT_TRUE((R.transpose() * R).isApprox(Matrix3d::Identity()));
+    EXPECT_NEAR(R(2, 2), 1.0, 1e-9);
+    EXPECT_NEAR(std::acos(R(0, 0)), w * total, 1e-6);
+    EXPECT_NEAR(p(0), v * std::sin(w * total) / w, 1e-6);
+    EXPECT_NEAR(p(1), v * (1 - std::cos(w * total)) / w, 1e-6);
+    EXPECT_NEAR(p(2), 0.0, 1e-12);
+}
+
+TEST(VelocityNoiseJacobians, MatchTheNumericalDerivatives) {
+    // Angular and Linear carry the negated derivative, Centered the plain one. Both are fine: these
+    // only ever enter the covariance as Phi_ns * Q * Phi_ns^T, which an overall sign flip leaves alone.
+    const double rl = 0.2, rr = 0.25, b = 0.6, eps = 1e-6;
+    WheelData data;
+    data.m1 = 1.3;
+    data.m2 = 2.1;
+    for (WheelType type : ALL_WHEEL_TYPES) {
+        Eigen::Matrix<double, 1, 2> Hwn, Hvn;
+        UpdaterWheel::ComputeVelocityNoiseJacobians(type, rl, rr, b, Hwn, Hvn);
+        const double sign = ModalityOf(type) == WheelModality::Centered ? 1.0 : -1.0;
+        for (int i = 0; i < 2; i++) {
+            WheelData plus = data, minus = data;
+            (i == 0 ? plus.m1 : plus.m2) += eps;
+            (i == 0 ? minus.m1 : minus.m2) -= eps;
+            const OdometryVelocity up = UpdaterWheel::ComputeOdometryVelocity(type, plus, rl, rr, b);
+            const OdometryVelocity down = UpdaterWheel::ComputeOdometryVelocity(type, minus, rl, rr, b);
+            EXPECT_NEAR(Hwn(0, i), sign * (up.w - down.w) / (2 * eps), 1e-8) << ToString(type) << " column " << i;
+            EXPECT_NEAR(Hvn(0, i), sign * (up.v - down.v) / (2 * eps), 1e-8) << ToString(type) << " column " << i;
+        }
+    }
+}
+
+TEST(MeasurementCovariance2D, IsDiagonalAndScalesWithTheStep) {
+    const double noise_w = 0.02, noise_v = 0.05, dt = 0.01;
+    const Eigen::Matrix2d ang = UpdaterWheel::ComputeMeasurementCovariance2D(WheelType::Wheel2DAng, noise_w, noise_v, dt);
+    const Eigen::Matrix2d lin = UpdaterWheel::ComputeMeasurementCovariance2D(WheelType::Wheel2DLin, noise_w, noise_v, dt);
+    const Eigen::Matrix2d cen = UpdaterWheel::ComputeMeasurementCovariance2D(WheelType::Wheel2DCen, noise_w, noise_v, dt);
+    EXPECT_DOUBLE_EQ(ang(0, 0), std::pow(noise_w, 2) / dt);
+    EXPECT_DOUBLE_EQ(ang(1, 1), std::pow(noise_w, 2) / dt);
+    EXPECT_DOUBLE_EQ(lin(0, 0), std::pow(noise_v, 2) / dt);
+    EXPECT_DOUBLE_EQ(lin(1, 1), std::pow(noise_v, 2) / dt);
+    EXPECT_DOUBLE_EQ(cen(0, 0), std::pow(noise_w, 2) / dt);
+    EXPECT_DOUBLE_EQ(cen(1, 1), std::pow(noise_v, 2) / dt);
+    for (const Eigen::Matrix2d &Q : {ang, lin, cen}) {
+        EXPECT_DOUBLE_EQ(Q(0, 1), 0.0);
+        EXPECT_DOUBLE_EQ(Q(1, 0), 0.0);
+    }
+}
+
+TEST(MeasurementCovariance3D, ConstrainsTheOffPlaneAxesWithTheConstraintNoise) {
+    const double noise_w = 0.02, noise_v = 0.05, noise_p = 0.001, b = 0.6, dt = 0.01;
+    for (WheelType type : ALL_WHEEL_TYPES) {
+        const Eigen::Matrix<double, 6, 6> Q =
+            UpdaterWheel::ComputeMeasurementCovariance3D(type, noise_w, noise_v, noise_p, b, dt);
+        EXPECT_TRUE(Q.isApprox(Eigen::Matrix<double, 6, 6>(Q.diagonal().asDiagonal()))) << ToString(type);
+        for (int i : {0, 1, 4, 5}) {
+            EXPECT_DOUBLE_EQ(Q(i, i), std::pow(noise_p, 2) / dt) << ToString(type) << " axis " << i;
+        }
+        if (ModalityOf(type) == WheelModality::Linear) {
+            EXPECT_DOUBLE_EQ(Q(2, 2), 2 * std::pow(noise_v, 2) / b / b / dt);
+            EXPECT_DOUBLE_EQ(Q(3, 3), std::pow(noise_v, 2) / 2 / dt);
+        } else {
+            EXPECT_DOUBLE_EQ(Q(2, 2), std::pow(noise_w, 2) / dt) << ToString(type);
+            EXPECT_DOUBLE_EQ(Q(3, 3), std::pow(noise_v, 2) / dt) << ToString(type);
+        }
+    }
 }


### PR DESCRIPTION
# Bring the wheel updater under unit test, then keep it there with a coverage gate.

| # | Scope | Status |
|---|---|---|
| 1/6 | Report unit test code coverage on every PR | shipped [#92] |
| 2/6 | Usable `OptionsWheel` defaults, one test file per header, shared fixture | shipped [#93] |
| 3/6 | Test the measurement stack seam, compare coverage against master | shipped [#94] |
| 4/6 | Test the preintegration helpers | **THIS PR** |
| 5/6 | Test `try_update` / `update` end to end, including chi2 rejection | next |
| 6/6 | Turn the coverage report into a merge gate | upcoming |

## Summary

`preintegration_2D` and `preintegration_3D` were two long functions that inlined
the same modality switch four times over. Nothing inside them could be reached
from a test.

Six stateless pieces are promoted to public statics on `UpdaterWheel`, the same
shape `ComputePreintegrationPartials2D` already uses. No new file, no friend
declarations:

- `ComputeOdometryVelocity` — one raw reading to angular and forward velocity
- `IntegrateMean2D` / `IntegrateMean3D` — the RK4 mean propagation
- `ComputeVelocityNoiseJacobians`
- `ComputeMeasurementCovariance2D` / `ComputeMeasurementCovariance3D`

The four copies of the modality switch collapse into one, and `preintegration_2D`
drops from about 150 lines to 40. The RK4 y stages go with them: `y` has always
been overwritten by its closed form, so those four lines were already dead and
became a compiler warning once the function was split.

11 new tests cover the extracted helpers — per-modality velocity resolution, the
straight line and constant turn cases for both integrators, agreement between the
2D and 3D integrators, the noise Jacobians against numerical derivatives, and the
shape of both measurement covariances.

## A defect the tests pin

`IntegrateMean2D` integrates `x` as path length rather than the arc chord. The RK4
stage headings `th2/th3/th4` are the heading change *inside* the step, so the
accumulated heading never reaches the `x` update. `y` escapes because it is
overwritten by a closed form that does use the accumulated heading. Meanwhile
`ComputePreintegrationPartials2D` linearizes `h_xv` about that same closed form, so
the propagation and its own Jacobian disagree.

The error is second order in the window length:

```
x_integrated / x_true = 1 / sinc(w * T) ~ 1 + (w * T)^2 / 6
```

and `update` resets the preintegrated state at every clone boundary, so `T` is one
clone interval. At 10-20 Hz clones and 1 rad/s that is under 0.2 mm on a 10 cm
step, a few percent of one wheel-noise sigma. It is not visible in ATE or NEES,
which is why the simulation gate never caught it, and it is not the cause of any
drift anyone is seeing today.

Pinned as-is, with an explanatory comment and a `DISABLED_` test holding the
expectation a fix should meet. Fixing it changes filter output and belongs in its
own PR gated by the evaluation report.

Also noted in a test comment, not a bug: `ComputeVelocityNoiseJacobians` returns the
negated derivative for the angular and linear types and the plain one for centered.
These only ever enter the covariance as `Phi_ns * Q * Phi_ns^T`, which an overall
sign flip leaves alone.

## Verification

- `catkin build mins` clean, no new warnings (the four dead-y warnings introduced by
  the split are removed with the dead code).
- `ctest` 3/3 suites pass, 38 cases in `test_UpdaterWheel`, one disabled.
- Local `gcovr`: `update/wheel` line coverage 63.1% (343/544), up from 39.0% at 3/6.
- Behavior preservation is the Evaluation Report on this PR — 8 seeds across the six
  wheel configurations, master versus this branch.

## Chain

Chains off PR 3/6 (#94).
Next in chain: PR 5/6 — test `try_update` / `update` end to end, which also picks up
`compute_linear_system_2D/3D`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
