### PR TITLE
wheel: carry the heading into the 2D RK4 displacement stages

### DIFF
--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -549,36 +549,35 @@ Vector3d UpdaterWheel::IntegrateMean2D(double dt, const OdometryVelocity &vel0, 
   double w = vel0.w;
   double v = vel0.v;
   double k1_th = -w * dt;
-  double k1_x = v * 1 * dt;
+  double k1_x = v * cos(th) * dt;
+  double k1_y = -v * sin(th) * dt;
 
   // k2 ================
-  double th2 = 0.5 * k1_th;
+  double th2 = th + 0.5 * k1_th;
   w += 0.5 * w_alpha * dt;
   v += 0.5 * v_jerk * dt;
   double k2_th = -w * dt;
   double k2_x = v * cos(th2) * dt;
+  double k2_y = -v * sin(th2) * dt;
 
   // k3 ================
-  double th3 = 0.5 * k2_th;
+  double th3 = th + 0.5 * k2_th;
   double k3_th = -w * dt;
   double k3_x = v * cos(th3) * dt;
+  double k3_y = -v * sin(th3) * dt;
 
   // k4 ================
-  double th4 = k3_th;
+  double th4 = th + k3_th;
   w += 0.5 * w_alpha * dt;
   v += 0.5 * v_jerk * dt;
   double k4_th = -w * dt;
   double k4_x = v * cos(th4) * dt;
+  double k4_y = -v * sin(th4) * dt;
 
   // integrated value
   double th_next = th + (1.0 / 6.0) * (k1_th + 2 * k2_th + 2 * k3_th + k4_th);
   double x_next = x + (1.0 / 6.0) * (k1_x + 2 * k2_x + 2 * k3_x + k4_x);
-  double y_next;
-
-  if (abs(vel0.w) < SMALL_ANGULAR_RATE) // In case w is too small, apply L'Hopital rule
-    y_next = y - vel0.v * sin(th - vel0.w * dt) * dt;
-  else // use discrete integration value for y because it is working better for some unknown reason...
-    y_next = y - (vel0.v * (cos(th - vel0.w * dt) - cos(th))) / vel0.w;
+  double y_next = y + (1.0 / 6.0) * (k1_y + 2 * k2_y + 2 * k3_y + k4_y);
 
   return {th_next, x_next, y_next};
 }

--- a/mins/tests/test_UpdaterWheel.cpp
+++ b/mins/tests/test_UpdaterWheel.cpp
@@ -836,41 +836,37 @@ TEST(IntegrateMean2D, ConstantTurnTracesACircularArc) {
         x = next(1);
         y = next(2);
     }
+    // The arc chord, which is what the exact solution of the unicycle model gives.
     const double total = N * dt;
     EXPECT_NEAR(th, -w * total, 1e-9);
+    EXPECT_NEAR(x, v * std::sin(w * total) / w, 1e-6);
     EXPECT_NEAR(y, v * (1 - std::cos(w * total)) / w, 1e-6);
-    // x comes out as the path length, not the arc chord: the stage headings th2/th3/th4 are the
-    // heading change inside the step, so the accumulated heading never reaches the x update. y is
-    // spared because it is overwritten by a closed form that does use it. Pinned as-is; the
-    // expectation this should meet is in the disabled test below.
-    EXPECT_NEAR(x, v * total, 1e-6);
 }
 
-TEST(IntegrateMean2D, DISABLED_ForwardDisplacementFollowsTheAccumulatedHeading) {
-    // The value ComputePreintegrationPartials2D linearizes about: h_xv is d/dv of the closed form
-    // -(v * (sin(th - w * dt) - sin(th))) / w, so the filter's Jacobian already assumes this arc.
-    const double w = 0.4;
-    const double v = 1.5;
-    const double dt = 0.001;
-    const int N = 500;
-    double th = 0.0, x = 0.0, y = 0.0;
-    for (int i = 0; i < N; i++) {
-        const Vector3d next = UpdaterWheel::IntegrateMean2D(dt, {w, v}, {w, v}, th, x, y);
-        th = next(0);
-        x = next(1);
-        y = next(2);
-    }
-    EXPECT_NEAR(x, v * std::sin(w * N * dt) / w, 1e-6);
-}
-
-TEST(IntegrateMean2D, NearZeroRateAgreesWithTheGeneralBranch) {
-    // Either side of the rate below which the closed form is replaced by its limit.
-    const double v = 1.5;
-    const double dt = 0.01;
+TEST(IntegrateMean2D, OneBigStepMatchesAFineSubdivisionUnderARamp) {
+    // RK4 is fourth order in the step, so a single step across a ramping rate and speed
+    // should land on the finely subdivided answer far closer than a first-order step would:
+    // freezing the velocities at the left endpoint instead is off by about 2e-2 here.
+    const double dt = 0.05;
+    const OdometryVelocity vel0{0.2, 1.0};
+    const OdometryVelocity vel1{0.8, 2.0};
     const double th = 0.3;
-    const Vector3d below = UpdaterWheel::IntegrateMean2D(dt, {0.99e-4, v}, {0.99e-4, v}, th, 0.0, 0.0);
-    const Vector3d above = UpdaterWheel::IntegrateMean2D(dt, {1.01e-4, v}, {1.01e-4, v}, th, 0.0, 0.0);
-    EXPECT_NEAR(below(2), above(2), 1e-8);
+
+    const Vector3d one = UpdaterWheel::IntegrateMean2D(dt, vel0, vel1, th, 0.0, 0.0);
+
+    const int N = 2000;
+    const double sub = dt / N;
+    Vector3d fine(th, 0.0, 0.0);
+    for (int i = 0; i < N; i++) {
+        const double a0 = double(i) / N, a1 = double(i + 1) / N;
+        const OdometryVelocity s0{vel0.w + a0 * (vel1.w - vel0.w), vel0.v + a0 * (vel1.v - vel0.v)};
+        const OdometryVelocity s1{vel0.w + a1 * (vel1.w - vel0.w), vel0.v + a1 * (vel1.v - vel0.v)};
+        fine = UpdaterWheel::IntegrateMean2D(sub, s0, s1, fine(0), fine(1), fine(2));
+    }
+
+    EXPECT_NEAR(one(0), fine(0), 1e-12);
+    EXPECT_NEAR(one(1), fine(1), 1e-6);
+    EXPECT_NEAR(one(2), fine(2), 1e-6);
 }
 
 TEST(IntegrateMean3D, StraightLineMatchesThe2DIntegrator) {


### PR DESCRIPTION
Now that #97 is merged this is a single commit on master: the fix and its tests, no
reorganisation in the diff.

## The defect

The RK4 in `IntegrateMean2D` set its stage headings to the heading change *inside* the step
rather than the heading itself, and the first stage went further and hardcoded the heading
at zero:

```cpp
double k1_x = v * 1 * dt;
double k1_y = -v * 0 * dt;
double th2 = 0.5 * k1_th;   // 0.5 * (-w * dt), not th + 0.5 * (-w * dt)
double th3 = 0.5 * k2_th;
double th4 = k3_th;
```

So the accumulated heading never reached the displacement stages and every step advanced
along the same direction. `x` accumulated the **path length** instead of the arc chord.
`y` escaped only because the closed form below overwrote whatever the RK4 produced for it
— which is exactly what the comment sitting on it was seeing:

```cpp
// use discrete integration value for y because it is working better for some unknown reason...
```

The reason was this bug.

## The fix

Both displacement stages start from `th`:

```cpp
double k1_x = v * cos(th) * dt;
double th2 = th + 0.5 * k1_th;
```

`x` and `y` are then both integrated to fourth order, so the closed-form `y` override goes
away and the `1 / w` singularity goes with it — `IntegrateMean2D` no longer needs the
small-rate guard at all. `ComputePreintegrationPartials2D` still does and is unchanged.

### On the Jacobian

`ComputePreintegrationPartials2D` linearizes about the constant-velocity closed form over
the step, which is not the exact derivative of an RK4 propagation. That is the usual
arrangement in an EKF: the propagated mean should be as accurate as you can afford, and the
Jacobian is a first-order approximation by construction. Lowering the propagation to a
left-endpoint closed form so the two agree exactly would trade real accuracy for a cosmetic
consistency.

## Expected impact: none visible

`update` resets the preintegrated state at every clone boundary, so the old error was
second order in one clone interval:

```
x_integrated / x_true = 1 / sinc(w * T) ~ 1 + (w * T)^2 / 6
```

At 10-20 Hz clones and 1 rad/s that is under 0.2 mm on a 10 cm step — a few percent of one
wheel-noise sigma. This is why it never showed up in ATE or NEES. The evaluation report on
this PR is the check that nothing moved.

## Verification

- `catkin build mins` clean, `ctest` 3/3 suites pass.
- `ConstantTurnTracesACircularArc` now asserts the chord `v * sin(w * T) / w` instead of the
  pinned path length `v * T`, and the `DISABLED_` test that held that expectation is folded
  into it and removed.
- New `OneBigStepMatchesAFineSubdivisionUnderARamp`: one 50 ms step across a ramping rate
  and speed lands within 1e-6 of a 2000-substep reference. A left-endpoint first-order step
  is off by 2e-2 on the same numbers.
- `NearZeroRateAgreesWithTheGeneralBranch` is deleted — there is no branch left in
  `IntegrateMean2D` to straddle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
