### PR TITLE
ci: show the coverage change as a number instead of coloured math

### DIFF
--- a/.github/scripts/gen_coverage_summary.py
+++ b/.github/scripts/gen_coverage_summary.py
@@ -45,13 +45,12 @@ def summarize(report):
     return totals
 
 
-def coloured(current, previous, covered, total):
-    """This branch's coverage, green above master and red below. GitHub renders the colour as math."""
-    counts = '(%d/%d)' % (covered, total)
+def cell(current, previous, covered, total):
+    """This branch's coverage, with the signed change against master when it moved."""
+    text = '%.1f%% (%d/%d)' % (current, covered, total)
     if previous is None or abs(current - previous) < 0.05:
-        return '%.1f%% %s' % (current, counts)
-    colour = 'green' if current > previous else 'red'
-    return r'$\color{%s}{%.1f\%%}$ %s' % (colour, current, counts)
+        return text
+    return '%s %+.1f' % (text, current - previous)
 
 
 def render(report, baseline):
@@ -68,13 +67,13 @@ def render(report, baseline):
         was_pct = pct(before[0], before[1]) if before else None
         lines.append('| `%s` | %s | %s |' % (
             name, 'n/a' if was_pct is None else '%.1f%%' % was_pct,
-            coloured(pct(line_covered, line_total), was_pct, line_covered, line_total)))
+            cell(pct(line_covered, line_total), was_pct, line_covered, line_total)))
     lines.append('')
     line_percent = report.get('line_percent', 0.0)
     was_overall = baseline.get('line_percent') if baseline else None
     lines.append('**Overall %s across `mins/src`, master is %s.**' % (
-        coloured(line_percent, was_overall, report.get('line_covered', 0),
-                 report.get('line_total', 0)),
+        cell(line_percent, was_overall, report.get('line_covered', 0),
+             report.get('line_total', 0)),
         'n/a' if was_overall is None else '%.1f%%' % was_overall))
     lines.append('')
     if baseline is None:


### PR DESCRIPTION
The coverage comment coloured its numbers with an inline LaTeX macro:

```python
r'$\color{%s}{%.1f\%%}$ %s'
```

The GitHub web UI renders that. The **mobile app does not render inline math at all**, so
the cell shows its own source and the column is unreadable on a phone:

```
$\color{green}{62.1%}$ (329/530)
```

Replaced with the signed change in plain text, which says the same thing and renders
everywhere:

| Area | master | this branch |
|------|--------|-------------|
| `update/wheel` | 39.1% | 62.1% (329/530) +23.0 |

**Overall 5.3% (500/9459) +1.2 across `mins/src`, master is 4.1%.**

Same 0.05 point threshold below which no change is shown. Comment generation only, no
change to what is measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
