### PR TITLE
wheel: drop the unused get_bounding_data

### DIFF
--- a/mins/src/update/wheel/UpdaterWheel.cpp
+++ b/mins/src/update/wheel/UpdaterWheel.cpp
@@ -787,22 +787,6 @@ void UpdaterWheel::preintegration_3D(double dt, const WheelData &data1, const Wh
   p_3D = new_p;
 }
 
-bool UpdaterWheel::get_bounding_data(double t_given, vector<WheelData> &data_stack, WheelData &data1, WheelData &data2) {
-
-  // check if requested time is in valid area
-  if (t_given > data_stack.back().time || t_given < data_stack.front().time)
-    return false;
-
-  // data_stack is ascending order!
-  for (int i = 0; i < (int)data_stack.size() - 1; i++) {
-    if (t_given >= data_stack.at(i).time && t_given < data_stack.at(i + 1).time) {
-      data1 = data_stack.at(i);
-      data2 = data_stack.at(i + 1);
-      return true;
-    }
-  }
-  return false;
-}
 void UpdaterWheel::feed_measurement(const WheelData &data) {
   // read the time before touching the stack, as data may alias one of its elements
   double time = data.time;

--- a/mins/src/update/wheel/UpdaterWheel.h
+++ b/mins/src/update/wheel/UpdaterWheel.h
@@ -376,9 +376,6 @@ private:
    */
   bool update(double time0, double time1);
 
-  /// get two wheel data bounding the t_given time
-  bool get_bounding_data(double t_given, std::vector<WheelData> &data_stack, WheelData &data1, WheelData &data2);
-
   /**
    * @brief Nice helper function that will linearly interpolate between two wheel messages.
    * This should be used instead of just "cutting" wheel messages that bound the clone times


### PR DESCRIPTION
`UpdaterWheel::get_bounding_data` has no callers anywhere in the repo.

The one call site that looks like it — `IW_Initializer.cpp:182` — is `Propagator`'s member
of the same name, operating on IMU data. `UpdaterWheel` cuts its own windows inside
`select_wheel_data`, walking the stack and calling `interpolate_data` directly, so this
copy has been dead since it was written.

Found while measuring coverage for the wheel unit test campaign: it is 15 unreachable
lines dragging the number the gate in #101's follow-up will be set against.

## Verification

`catkin build mins` clean, `ctest` 3/3 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
