### PR TITLE
ci: report gtest cases, fix the calib table header, unfold the eval report

### DIFF
--- a/.github/scripts/calib_plot.py
+++ b/.github/scripts/calib_plot.py
@@ -229,7 +229,7 @@ def main():
     md = '\n'.join([
         f'### {icon} {args.title}',
         '',
-        '| Parameter | final |error| | final σ | ±3σ |',
+        '| Parameter | final abs error | final σ | ±3σ |',
         '|---|---|---|---|',
     ] + rows)
 

--- a/.github/scripts/eval_report.py
+++ b/.github/scripts/eval_report.py
@@ -52,7 +52,7 @@ def delta(pr_mean, ma_mean):
 def main():
     config = sys.argv[1]
     rows = parse(sys.argv[2])
-    out = [f"<details><summary><b>{config}</b></summary>\n"]
+    out = [f"<details open><summary><b>{config}</b></summary>\n"]
 
     if "master" not in rows or "pr" not in rows:
         out.append(f"> Note: could not parse results for `{config}` "
@@ -85,5 +85,5 @@ if __name__ == "__main__":
         main()
     except Exception as exc:  # never break the report job
         cfg = sys.argv[1] if len(sys.argv) > 1 else "?"
-        print(f"<details><summary><b>{cfg}</b></summary>\n\n"
+        print(f"<details open><summary><b>{cfg}</b></summary>\n\n"
               f"> Note: report parsing error: `{exc}`\n\n</details>")

--- a/.github/scripts/gen_unit_test_summary.py
+++ b/.github/scripts/gen_unit_test_summary.py
@@ -1,20 +1,53 @@
-import re, os, sys
+import glob, re, os, sys
+import xml.etree.ElementTree as ET
 
 text = open(sys.argv[1]).read() if len(sys.argv) > 1 and os.path.exists(sys.argv[1]) else ''
 out_file = sys.argv[2] if len(sys.argv) > 2 else None
+# Directory the test binaries drop their GTEST_OUTPUT xml into. ctest counts binaries, which
+# says 3 no matter how many cases are in them, so the case counts come from the xml instead.
+xml_dir = sys.argv[3] if len(sys.argv) > 3 else None
 
 tests = re.findall(r'\d+/\d+ Test #\d+: (\S+)[\s.]+(\w+)\s+([\d.]+) sec', text)
 total_line = re.search(r'(\d+)% tests passed, (\d+) tests failed out of (\d+)', text)
 
-lines = ['<!-- mins-unit-test-report -->', '## Unit Test Results', '', '| Test | Result | Duration |', '|------|--------|----------|']
+
+def read_cases(directory):
+    """{binary name: (passed, total)} plus the names of the cases that did not pass."""
+    counts, failures = {}, []
+    for path in sorted(glob.glob(os.path.join(directory or '', '*.xml'))):
+        root = ET.parse(path).getroot()
+        total = int(root.get('tests', 0)) - int(root.get('disabled', 0))
+        bad = int(root.get('failures', 0)) + int(root.get('errors', 0))
+        counts[os.path.splitext(os.path.basename(path))[0]] = (total - bad, total)
+        for case in root.iter('testcase'):
+            if case.find('failure') is not None or case.find('error') is not None:
+                failures.append(case.get('classname') + '.' + case.get('name'))
+    return counts, failures
+
+
+cases, failed_cases = read_cases(xml_dir) if xml_dir else ({}, [])
+
+lines = ['<!-- mins-unit-test-report -->', '## Unit Test Results', '',
+         '| Test | Cases | Result | Duration |', '|------|-------|--------|----------|']
 for name, status, duration in tests:
     icon = '✅' if status == 'Passed' else '❌'
-    lines.append(f'| `{name}` | {icon} {status} | {duration}s |')
+    passed, total = cases.get(name, (None, None))
+    count = f'{passed}/{total}' if total is not None else '-'
+    lines.append(f'| `{name}` | {count} | {icon} {status} | {duration}s |')
 lines.append('')
+if failed_cases:
+    lines.append('Failed cases:')
+    lines += [f'- `{name}`' for name in failed_cases]
+    lines.append('')
 if total_line:
     _, failed, total = total_line.groups()
     passed = int(total) - int(failed)
-    lines.append(f'**{passed}/{total} passed**')
+    tally = f'**{passed}/{total} test binaries passed**'
+    if cases:
+        case_total = sum(t for _, t in cases.values())
+        case_passed = sum(p for p, _ in cases.values())
+        tally += f', {case_passed}/{case_total} cases'
+    lines.append(tally)
 elif not tests:
     lines.append('*No test results found (build may have failed)*')
 

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -34,11 +34,12 @@ jobs:
             catkin build mins
             cd /catkin_ws/build/mins
             set +e
-            ctest --output-on-failure > /results/ctest.txt 2>&1
+            # ctest only counts test binaries; per-case numbers come from the gtest xml.
+            GTEST_OUTPUT=xml:/results/gtest/ ctest --output-on-failure > /results/ctest.txt 2>&1
             echo $? > /results/exit.txt
             cat /results/ctest.txt
           '
-          python3 .github/scripts/gen_unit_test_summary.py /tmp/mins_tests/ctest.txt unit_test_report.md || true
+          python3 .github/scripts/gen_unit_test_summary.py /tmp/mins_tests/ctest.txt unit_test_report.md /tmp/mins_tests/gtest || true
           exit $(cat /tmp/mins_tests/exit.txt 2>/dev/null || echo 1)
       - name: Post unit test report to PR
         if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
Three small fixes to what CI posts on a PR.

## Unit test comment counted binaries, not cases

`ctest` tests are test binaries, so the comment said **3/3 passed** whether the binaries held
three cases or three hundred. `GTEST_OUTPUT=xml:` now drops a per-binary xml next to the ctest
log and the summary reads the case numbers out of it:

| Test | Cases | Result | Duration |
|------|-------|--------|----------|
| `test_UpdaterVicon` | 1/1 | ✅ Passed | 0.08s |
| `test_UpdaterWheel` | 38/38 | ✅ Passed | 0.40s |
| `test_WheelTypes` | 7/7 | ✅ Passed | 0.00s |

**3/3 test binaries passed**, 46/46 cases

A failing run also names the cases, so the comment says which one broke without opening the log.

## Calibration per-parameter tables did not render

The header cell read `final |error|`. Those inner pipes make it a six-column header over a
four-column delimiter row, so GitHub stops treating the block as a table and prints the raw
markdown — which is what the per-parameter section has been showing. It now reads
`final abs error`.

## Simulation regression sections start open

They are the point of that comment; `<details open>` instead of a click per config.

## Verification

Ran `ctest` under `GTEST_OUTPUT` locally and rendered the summary from the real xml (the table
above). Also rendered it against a doctored xml with a failing case to check the Cases column
and the failed-case list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
