### PR TITLE
ci: gate the build on wheel coverage dropping against master (6/6)

### DIFF
--- a/.github/scripts/gen_coverage_summary.py
+++ b/.github/scripts/gen_coverage_summary.py
@@ -3,6 +3,15 @@ import json, os, sys
 
 MARKER = '<!-- mins-coverage-report -->'
 
+# The gate only guards the one directory that has real unit tests. Gating the whole of
+# mins/src would fail any PR that adds a file to a directory with no tests at all, which
+# is most of them, so it would be turned off within a week.
+GATED_GROUP = 'update/wheel'
+
+# Percentage points a drop is allowed before the build fails. Small but not zero: line
+# attribution moves a little when unrelated code around it is rebuilt.
+GATE_TOLERANCE = 0.5
+
 # Directories we care about enough to give their own row. Order is the order shown, and the
 # first matching prefix wins, so the per-sensor rows have to come before the update catch-all.
 GROUPS = [
@@ -53,6 +62,19 @@ def cell(current, previous, covered, total):
     return '%s %+.1f' % (text, current - previous)
 
 
+def gate(totals, was):
+    """The reason to fail the build, or None when coverage held."""
+    if GATED_GROUP not in totals or GATED_GROUP not in was:
+        return None
+    current = pct(totals[GATED_GROUP][0], totals[GATED_GROUP][1])
+    previous = pct(was[GATED_GROUP][0], was[GATED_GROUP][1])
+    if current >= previous - GATE_TOLERANCE:
+        return None
+    return ('Line coverage on `%s` fell from %.1f%% to %.1f%%, past the %.1f point tolerance. '
+            'Cover the new lines, or say on the PR why the drop is the right call.'
+            % (GATED_GROUP, previous, current, GATE_TOLERANCE))
+
+
 def render(report, baseline):
     totals = summarize(report)
     was = summarize(baseline) if baseline else {}
@@ -80,8 +102,12 @@ def render(report, baseline):
         lines.append('No master baseline was available for this run. It fills in once a master '
                      'build has published a coverage report.')
         lines.append('')
+    failure = gate(totals, was)
+    if failure:
+        lines.append('**Coverage gate failed.** ' + failure)
+        lines.append('')
     lines.append('Full HTML report is in the `coverage-report` artifact of this run.')
-    return '\n'.join(lines)
+    return '\n'.join(lines), failure
 
 
 json_path = sys.argv[1]
@@ -92,8 +118,9 @@ baseline = None
 if baseline_path and os.path.exists(baseline_path):
     baseline = json.load(open(baseline_path))
 
+failure = None
 if os.path.exists(json_path):
-    summary = render(json.load(open(json_path)), baseline)
+    summary, failure = render(json.load(open(json_path)), baseline)
 else:
     summary = '\n'.join([MARKER, '## Unit Test Code Coverage', '',
                          '*Report not generated - check the CI log.*'])
@@ -107,3 +134,5 @@ if gss:
 if out_file:
     with open(out_file, 'w') as f:
         f.write(summary + '\n')
+if failure:
+    sys.exit(1)

--- a/.github/workflows/build_ros1_noetic.yml
+++ b/.github/workflows/build_ros1_noetic.yml
@@ -76,7 +76,7 @@ jobs:
           if [ -n "$run_id" ]; then
             gh run download "$run_id" --name coverage-report --dir /tmp/mins_baseline || true
           fi
-      - name: Measure unit test code coverage
+      - name: Measure unit test code coverage and gate on it
         # Separate build: -O3 inlines away the lines we want to count, so this one is -O0
         # with --coverage. It reuses the image from the test step rather than a second job,
         # which would mean rebuilding the whole docker image.


### PR DESCRIPTION
# Bring the wheel updater under unit test, then keep it there with a coverage gate.

| # | Scope | Status |
|---|---|---|
| 1/6 | gcovr coverage report posted on every PR | shipped #92 |
| 2/6 | wheel-only state fixture and the option defaults it rests on | shipped #93 |
| 3/6 | seam tests: measurement stack, selection, odometry velocities | shipped #94 |
| 4/6 | preintegration helpers: mean integration, noise Jacobians, measurement covariance | shipped #97 |
| 5/6 | `try_update` / `update` end to end, including `compute_linear_system_2D/3D` | shipped #101 |
| 6/6 | turn the coverage report into a gate | **THIS PR** |

## Summary

The coverage report has been informational since #92. This makes it fail the build, on two
deliberate restrictions:

**It guards `mins/src/update/wheel/` only.** A repo-wide gate fails any PR that adds a file to
a directory with no tests at all, which is most of them, so it would be switched off within a
week. The one directory that has real tests is the one worth defending.

**It fails on a drop against the master baseline, not on an absolute threshold.** Nobody has to
remember to raise a number when coverage improves, and a PR is only ever measured against what
master already had. Tolerance is 0.5 percentage points, because line attribution moves a little
when unrelated code around it is rebuilt.

The comment is unchanged except for a line naming the failure when the gate trips. Pushes to
master never gate: the baseline is only fetched on `pull_request`, and with no baseline there is
nothing to compare against.

## Verification

Ran the script against a real gcovr summary twice — once with itself as the baseline (exit 0),
once against a baseline doctored to 100% on the wheel directory:

> **Coverage gate failed.** Line coverage on `update/wheel` fell from 100.0% to 64.0%, past the
> 0.5 point tolerance. Cover the new lines, or say on the PR why the drop is the right call.

exit 1, and the upload and comment steps that follow are `if: always()`, so the report still
posts on a failing run.

## Chain

Chains off PR 5/6 (#101). Last in the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCNrFoYaMLUTzzwFFMoD7
